### PR TITLE
fix(injuries): decrement days remaining on day advance

### DIFF
--- a/src-tauri/crates/ofm_core/src/turn/mod.rs
+++ b/src-tauri/crates/ofm_core/src/turn/mod.rs
@@ -16,6 +16,19 @@ use log::{debug, info};
 pub use news::generate_matchday_news;
 pub use post_match::apply_match_report;
 
+/// Progress injury recovery by one day for all currently injured players.
+/// Injuries with 1 day remaining are cleared.
+fn progress_injury_recovery(game: &mut Game) {
+    for player in game.players.iter_mut() {
+        if let Some(mut injury) = player.injury.take() {
+            if injury.days_remaining > 1 {
+                injury.days_remaining -= 1;
+                player.injury = Some(injury);
+            }
+        }
+    }
+}
+
 /// Process a single day advance.
 pub fn process_day(game: &mut Game) {
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
@@ -45,6 +58,7 @@ pub fn process_day(game: &mut Game) {
 
     // Player conversations, random events, and scouting
     player_events::check_player_events(game);
+    progress_injury_recovery(game);
     random_events::check_random_events(game);
     scouting::process_scouting(game);
 
@@ -64,6 +78,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     board_objectives::update_objective_progress(game);
 
     player_events::check_player_events(game);
+    progress_injury_recovery(game);
     random_events::check_random_events(game);
     scouting::process_scouting(game);
     news::generate_pre_match_messages(game, &today);

--- a/src-tauri/crates/ofm_core/src/turn/mod.rs
+++ b/src-tauri/crates/ofm_core/src/turn/mod.rs
@@ -20,11 +20,11 @@ pub use post_match::apply_match_report;
 /// Injuries with 1 day remaining are cleared.
 fn progress_injury_recovery(game: &mut Game) {
     for player in game.players.iter_mut() {
-        if let Some(mut injury) = player.injury.take() {
-            if injury.days_remaining > 1 {
-                injury.days_remaining -= 1;
-                player.injury = Some(injury);
-            }
+        if let Some(mut injury) = player.injury.take()
+            && injury.days_remaining > 1
+        {
+            injury.days_remaining -= 1;
+            player.injury = Some(injury);
         }
     }
 }

--- a/src-tauri/crates/ofm_core/tests/turn_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/turn_tests.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::league::{Fixture, FixtureStatus, League, StandingEntry};
 use domain::manager::Manager;
-use domain::player::{Player, PlayerAttributes, Position};
+use domain::player::{Injury, Player, PlayerAttributes, Position};
 use domain::team::Team;
 use engine::Side;
 use engine::report::{GoalDetail, MatchReport, PlayerMatchStats, TeamStats};
@@ -318,6 +318,37 @@ fn process_day_no_league_no_crash() {
 }
 
 #[test]
+fn process_day_progresses_injury_recovery() {
+    let mut game = make_game_with_match();
+    // Ensure non-match path and skip user-specific random/player events.
+    game.league.as_mut().unwrap().fixtures[0].date = "2025-06-20".to_string();
+    game.manager.team_id = None;
+
+    let short = game.players.iter_mut().find(|p| p.id == "t1_def0").unwrap();
+    short.injury = Some(Injury {
+        name: "Hamstring".to_string(),
+        days_remaining: 1,
+    });
+    let long = game.players.iter_mut().find(|p| p.id == "t1_mid0").unwrap();
+    long.injury = Some(Injury {
+        name: "Ankle".to_string(),
+        days_remaining: 3,
+    });
+
+    turn::process_day(&mut game);
+
+    let short_after = game.players.iter().find(|p| p.id == "t1_def0").unwrap();
+    assert!(short_after.injury.is_none(), "1-day injury should clear");
+
+    let long_after = game.players.iter().find(|p| p.id == "t1_mid0").unwrap();
+    assert_eq!(
+        long_after.injury.as_ref().map(|inj| inj.days_remaining),
+        Some(2),
+        "Injury should decrement by one day"
+    );
+}
+
+#[test]
 fn process_day_generates_match_result_message() {
     let mut game = make_game_with_match();
     turn::process_day(&mut game);
@@ -355,6 +386,31 @@ fn finish_live_match_day_advances_clock() {
     let before = game.clock.current_date;
     turn::finish_live_match_day(&mut game);
     assert_eq!((game.clock.current_date - before).num_days(), 1);
+}
+
+#[test]
+fn finish_live_match_day_progresses_injury_recovery() {
+    let mut game = make_game_with_match();
+    // Skip user-specific random/player events.
+    game.manager.team_id = None;
+
+    let recovering = game.players.iter_mut().find(|p| p.id == "t2_def1").unwrap();
+    recovering.injury = Some(Injury {
+        name: "Knee".to_string(),
+        days_remaining: 2,
+    });
+
+    turn::finish_live_match_day(&mut game);
+
+    let recovering_after = game.players.iter().find(|p| p.id == "t2_def1").unwrap();
+    assert_eq!(
+        recovering_after
+            .injury
+            .as_ref()
+            .map(|inj| inj.days_remaining),
+        Some(1),
+        "Injury should decrement by one day at end of live-match day"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add daily injury recovery progression in `ofm_core::turn`
- decrement `injury.days_remaining` by 1 on each day advance and clear the injury at 0
- run recovery progression for both normal day processing and live-match day completion paths

## Root Cause
Injuries were assigned and displayed in the UI, but there was no daily backend logic decrementing `days_remaining`.

## Impact
Players marked as unavailable now recover over time as expected, and the remaining days counter updates correctly day-by-day.

## Validation
- `cd src-tauri && cargo test -p ofm_core --test turn_tests`
- Result: `46 passed, 0 failed`

Closes #119
