### PR TITLE
fix(issue-129): board confidence msg id changed to use last loss date

### DIFF
--- a/src-tauri/crates/ofm_core/src/random_events/mod.rs
+++ b/src-tauri/crates/ofm_core/src/random_events/mod.rs
@@ -309,7 +309,11 @@ pub fn check_random_events(game: &mut Game) {
                         }
                     })
                     .count();
-                let msg_id = format!("board_confidence_{}", today);
+                let last_loss_date = last3
+                    .last()
+                    .map(|f| f.date.clone())
+                    .unwrap_or(today.clone());
+                let msg_id = format!("board_confidence_{}", last_loss_date);
                 if losses >= 3 && !existing_ids.contains(&msg_id) {
                     new_messages.push(builders_reports::board_confidence_message(&msg_id, &today));
                 }

--- a/src-tauri/crates/ofm_core/tests/random_events_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/random_events_tests.rs
@@ -339,6 +339,10 @@ fn check_random_events_board_confidence_triggers_on_losses() {
         1,
         "Board confidence message should trigger after 3 losses"
     );
+    // Use the most recent lost match as the msg id
+    assert_eq!(board_msgs[0].id, "board_confidence_2025-06-10");
+    // Date of the message should still be game date
+    assert_eq!(board_msgs[0].date, _today);
     assert_eq!(board_msgs[0].category, MessageCategory::BoardDirective);
     assert_eq!(board_msgs[0].priority, MessagePriority::Urgent);
     assert_choose_option_keys(board_msgs[0]);


### PR DESCRIPTION
This should fix #129

Previously the message ID contained the current game date, this meant the de-duplication check failed and a new message was sent every day.

The fix changes the internal ID to use the last loss date as the msg ID, but still keeps the game date as the date of the message.

Tests updated.

Note: running `cargo fmt` and `cargo clippy` changed a lot of files, suggest handling in another PR but happy to take your steer.