### PR TITLE
fix(match): guard against null snapshot from get_match_snapshot

### DIFF
--- a/src/pages/MainMenu.test.tsx
+++ b/src/pages/MainMenu.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
 import type { ComponentPropsWithoutRef } from "react";
 

--- a/src/pages/MatchSimulation.tsx
+++ b/src/pages/MatchSimulation.tsx
@@ -106,7 +106,8 @@ export default function MatchSimulation() {
         matchMode,
       });
       try {
-        const snap = await invoke<MatchSnapshot>("get_match_snapshot");
+        const snap = await invoke<MatchSnapshot | null>("get_match_snapshot");
+        if (!snap) throw new Error("No active match snapshot");
         console.info("[MatchSimulation] fetchSnapshot:success", {
           awayPlayers: snap.away_team.players.length,
           awayTeam: snap.away_team.name,


### PR DESCRIPTION
Closes #140

## Summary

`MatchSimulation.fetchSnapshot` typed the Tauri invoke result as non-nullable `MatchSnapshot`, but the command can return `null` on some code paths. When it does, the success `console.info` optimistically dereferences `snap.away_team` before any null check, throwing a `TypeError` that the existing catch block then logs as a misleading "Failed to get match snapshot".

The fix narrows the invoke return type, throws a descriptive error on `null`, and lets the existing catch branch (navigate to `/dashboard` / restore from `fixtureIndex`) run uniformly. This update also imports `afterEach` in `MainMenu.test.tsx` so TypeScript verification passes cleanly.

## Change

```diff
-const snap = await invoke<MatchSnapshot>("get_match_snapshot");
+const snap = await invoke<MatchSnapshot | null>("get_match_snapshot");
+if (!snap) throw new Error("No active match snapshot");
```

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test -- src/pages/MatchSimulation src/pages/MainMenu`
- [x] Manually reproduced the TypeError pre-fix and confirmed it no longer fires post-fix (the catch block now takes the redirect-to-/dashboard path cleanly)

## Context

Encountered while running a Playwright smoke test for #139 (zh-CN i18n). Split into a separate PR to keep #139 focused on the locale file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
