### PR TITLE
fix: write imported world JSON to disk on import

### DIFF
--- a/src/pages/MainMenu.test.tsx
+++ b/src/pages/MainMenu.test.tsx
@@ -545,10 +545,8 @@ describe("MainMenu", () => {
     expect(mockedInvoke).not.toHaveBeenCalledWith("list_world_databases");
   });
 
-  it("does not fall back to a random world when imported database writing fails", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => { });
-
-    mockedInvoke.mockImplementation(async (command: string) => {
+  it("passes the imported world path directly when starting a new career", async () => {
+    mockedInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
       if (command === "list_world_databases") {
         return [
           {
@@ -558,24 +556,19 @@ describe("MainMenu", () => {
             team_count: 8,
             player_count: 160,
             source: "imported",
-            path: "",
+            path: "/tmp/imported-world.json",
             history_mode: "reference",
           },
         ];
       }
 
-      if (command === "write_temp_database") {
-        throw new Error("write failed");
-      }
-
       if (command === "start_new_game") {
+        expect(args?.worldSource).toBe("file:/tmp/imported-world.json");
         return { id: "game-1" };
       }
 
       return null;
     });
-
-    sessionStorage.setItem("imported_world_json", "{\"name\":\"Imported World\"}");
 
     render(<MainMenu />);
 
@@ -593,17 +586,16 @@ describe("MainMenu", () => {
     fireEvent.click(screen.getByText("start-world"));
 
     await waitFor(() => {
-      expect(mockedInvoke).toHaveBeenCalledWith("write_temp_database", {
-        json: "{\"name\":\"Imported World\"}",
-      });
+      expect(mockedInvoke).toHaveBeenCalledWith(
+        "start_new_game",
+        expect.objectContaining({
+          worldSource: "file:/tmp/imported-world.json",
+        }),
+      );
     });
 
-    expect(mockedInvoke).not.toHaveBeenCalledWith(
-      "start_new_game",
-      expect.anything(),
-    );
-    expect(alertMock).toHaveBeenCalledWith("menu.failedStartGame");
-    expect(navigateMock).not.toHaveBeenCalledWith("/select-team");
+    expect(mockedInvoke).not.toHaveBeenCalledWith("write_temp_database", expect.anything());
+    expect(navigateMock).toHaveBeenCalledWith("/select-team");
   });
 
   it("passes the selected generated history depth when starting a new career", async () => {

--- a/src/pages/MainMenu.test.tsx
+++ b/src/pages/MainMenu.test.tsx
@@ -546,7 +546,7 @@ describe("MainMenu", () => {
   });
 
   it("passes the imported world path directly when starting a new career", async () => {
-    mockedInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+    mockedInvoke.mockImplementation(async (command: string, args?) => {
       if (command === "list_world_databases") {
         return [
           {
@@ -563,7 +563,7 @@ describe("MainMenu", () => {
       }
 
       if (command === "start_new_game") {
-        expect(args?.worldSource).toBe("file:/tmp/imported-world.json");
+        expect((args as Record<string, unknown>)?.worldSource).toBe("file:/tmp/imported-world.json");
         return { id: "game-1" };
       }
 

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -428,6 +428,7 @@ export default function MainMenu() {
       try {
         const json = reader.result as string;
         const parsed = JSON.parse(json);
+        const path = await invoke<string>("write_temp_database", { json });
         const info: WorldDatabaseInfo = {
           id: `file:${file.name}`,
           name: parsed.name || file.name.replace(".json", ""),
@@ -444,10 +445,8 @@ export default function MainMenu() {
               ? parsed.metadata.snapshot_date
               : null,
           source: "imported",
-          path: "", // will use the parsed data directly
+          path,
         };
-        // Store the raw JSON in sessionStorage so we can write it to a temp path
-        sessionStorage.setItem("imported_world_json", json);
         setWorldDatabases((prev) => {
           const filtered = prev.filter((d) => d.source !== "imported");
           return [...filtered, info];
@@ -479,16 +478,11 @@ export default function MainMenu() {
       let worldSource: string | undefined = selectedWorldId;
       if (selectedWorldId === "random") {
         worldSource = undefined;
-      } else if (
-        selectedWorldId.startsWith("file:") &&
-        sessionStorage.getItem("imported_world_json")
-      ) {
-        // For imported files, write to a temp location first
-        const json = sessionStorage.getItem("imported_world_json")!;
-        const path = await invoke<string>("write_temp_database", {
-          json,
-        });
-        worldSource = `file:${path}`;
+      } else {
+        const selectedDb = worldDatabases.find((db) => db.id === selectedWorldId);
+        if (selectedDb?.path) {
+          worldSource = `file:${selectedDb.path}`;
+        }
       }
 
       const game = await invoke<GameStateData>("start_new_game", {
@@ -499,7 +493,6 @@ export default function MainMenu() {
         startupOptions,
         worldSource,
       });
-      sessionStorage.removeItem("imported_world_json");
       setGameState(game);
       navigate("/select-team");
     } catch (error) {


### PR DESCRIPTION
## Summary
- Write imported world JSON to a temp file immediately when the user selects a file
- Store the returned path on `WorldDatabaseInfo.path` instead of deferring via `sessionStorage`
- Pass `file:${path}` directly to `start_new_game`, same as bundled world databases

## Motivation
Avoids browser sessionStorage quota (~5 MB), which blocks large imported world files
Imported worlds previously kept raw JSON in `sessionStorage` and only called `write_temp_database` at career start. That delayed failures, added special-case logic in `handleStartGame`, and made the flow depend on session state.

Fixes #169 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved imported world-file workflow: imported JSON is now saved as a filesystem path (not kept in browser session storage) and the launch flow uses that path when starting a game, enabling smoother navigation to team selection.

* **Tests**
  * Updated tests to validate the new import-to-path flow and successful game start with imported worlds (removed previous error/fallback expectations).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfootmanager/openfootmanager/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->