### PR TITLE
fix: show team name on load game save cards

### DIFF
--- a/src-tauri/crates/db/src/save_index.rs
+++ b/src-tauri/crates/db/src/save_index.rs
@@ -327,6 +327,25 @@ mod tests {
     }
 
     #[test]
+    fn test_load_index_defaults_missing_team_name() {
+        let legacy_json = r#"{
+            "version": 1,
+            "saves": [{
+                "id": "save-001",
+                "name": "Career",
+                "manager_name": "John Smith",
+                "db_filename": "save-001.db",
+                "checksum": "abc123",
+                "created_at": "2026-01-01",
+                "last_played_at": "2026-01-02"
+            }]
+        }"#;
+
+        let index: SaveIndex = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(index.saves[0].team_name, "");
+    }
+
+    #[test]
     fn test_save_index_serialization_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let index_path = dir.path().join("save_index.json");

--- a/src-tauri/crates/db/src/save_index.rs
+++ b/src-tauri/crates/db/src/save_index.rs
@@ -3,7 +3,10 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::Path;
 
+use ofm_core::game::Game;
+
 use crate::game_database::GameDatabase;
+use crate::game_persistence::GamePersistenceReader;
 use crate::repositories::meta_repo;
 
 /// A single entry in the save index, representing one save session.
@@ -12,6 +15,8 @@ pub struct SaveEntry {
     pub id: String,
     pub name: String,
     pub manager_name: String,
+    #[serde(default)]
+    pub team_name: String,
     pub db_filename: String,
     pub checksum: String,
     pub created_at: String,
@@ -56,6 +61,7 @@ impl SaveIndex {
         if let Some(existing) = self.saves.iter_mut().find(|e| e.id == entry.id) {
             existing.name = entry.name.clone();
             existing.manager_name = entry.manager_name.clone();
+            existing.team_name = entry.team_name.clone();
             existing.checksum = entry.checksum.clone();
             existing.last_played_at = entry.last_played_at.clone();
             true
@@ -162,6 +168,18 @@ pub fn rebuild_index(saves_dir: &Path) -> Result<(SaveIndex, Vec<DbValidation>),
     Ok((index, validations))
 }
 
+pub fn save_entry_metadata_from_game(game: &Game) -> (String, String) {
+    let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+    let team_name = game
+        .manager
+        .team_id
+        .as_ref()
+        .and_then(|team_id| game.teams.iter().find(|team| team.id == *team_id))
+        .map(|team| team.name.clone())
+        .unwrap_or_default();
+    (manager_name, team_name)
+}
+
 /// Validate a single `.db` file: check schema and extract metadata.
 fn validate_db_file(path: &Path) -> Result<SaveEntry, String> {
     let db = GameDatabase::open(path)?;
@@ -181,10 +199,15 @@ fn validate_db_file(path: &Path) -> Result<SaveEntry, String> {
         .unwrap_or("unknown.db")
         .to_string();
 
+    let (manager_name, team_name) = GamePersistenceReader::read_game(&db)
+        .map(|game| save_entry_metadata_from_game(&game))
+        .unwrap_or_default();
+
     Ok(SaveEntry {
         id: meta.save_id.clone(),
         name: meta.save_name,
-        manager_name: String::new(), // Will be filled from managers table later
+        manager_name,
+        team_name,
         db_filename: filename,
         checksum,
         created_at: meta.created_at,
@@ -226,6 +249,7 @@ mod tests {
             id: "save-001".to_string(),
             name: "Test Career".to_string(),
             manager_name: "John Smith".to_string(),
+            team_name: String::new(),
             db_filename: "save-001.db".to_string(),
             checksum: "abc123".to_string(),
             created_at: "2026-01-01".to_string(),
@@ -245,6 +269,7 @@ mod tests {
             id: "save-001".to_string(),
             name: "Old Name".to_string(),
             manager_name: "John".to_string(),
+            team_name: String::new(),
             db_filename: "save-001.db".to_string(),
             checksum: "old".to_string(),
             created_at: "2026-01-01".to_string(),
@@ -255,6 +280,7 @@ mod tests {
             id: "save-001".to_string(),
             name: "New Name".to_string(),
             manager_name: "John".to_string(),
+            team_name: String::new(),
             db_filename: "save-001.db".to_string(),
             checksum: "new".to_string(),
             created_at: "2026-01-01".to_string(),
@@ -273,6 +299,7 @@ mod tests {
             id: "nonexistent".to_string(),
             name: "x".to_string(),
             manager_name: "x".to_string(),
+            team_name: String::new(),
             db_filename: "x.db".to_string(),
             checksum: "x".to_string(),
             created_at: "x".to_string(),
@@ -288,6 +315,7 @@ mod tests {
             id: "save-001".to_string(),
             name: "Career".to_string(),
             manager_name: "John".to_string(),
+            team_name: String::new(),
             db_filename: "save-001.db".to_string(),
             checksum: "abc".to_string(),
             created_at: "2026-01-01".to_string(),
@@ -308,6 +336,7 @@ mod tests {
             id: "save-001".to_string(),
             name: "Career".to_string(),
             manager_name: "John".to_string(),
+            team_name: String::new(),
             db_filename: "save-001.db".to_string(),
             checksum: "abc123".to_string(),
             created_at: "2026-01-01".to_string(),
@@ -511,6 +540,7 @@ mod tests {
             id: "existing".to_string(),
             name: "Existing".to_string(),
             manager_name: "John".to_string(),
+            team_name: String::new(),
             db_filename: "existing.db".to_string(),
             checksum: "abc".to_string(),
             created_at: "2026-01-01".to_string(),

--- a/src-tauri/crates/db/src/save_index_manager.rs
+++ b/src-tauri/crates/db/src/save_index_manager.rs
@@ -81,6 +81,7 @@ mod tests {
             id: "save-1".to_string(),
             name: "Career".to_string(),
             manager_name: "John Smith".to_string(),
+            team_name: "London FC".to_string(),
             db_filename: "save-1.db".to_string(),
             checksum: "checksum".to_string(),
             created_at: "2026-01-01T00:00:00Z".to_string(),

--- a/src-tauri/crates/db/src/save_manager.rs
+++ b/src-tauri/crates/db/src/save_manager.rs
@@ -81,7 +81,9 @@ impl SaveManager {
             };
 
             let (manager_name, team_name) = save_entry_metadata_from_game(&game);
-            if team_name.is_empty() && save.manager_name.is_empty() {
+            let can_backfill_team = !team_name.is_empty();
+            let can_backfill_manager = save.manager_name.is_empty() && !manager_name.is_empty();
+            if !can_backfill_team && !can_backfill_manager {
                 continue;
             }
 
@@ -90,7 +92,13 @@ impl SaveManager {
                 save.manager_name = manager_name;
             }
 
-            self.save_index.update_save(save.clone())?;
+            if let Err(error) = self.save_index.update_save(save.clone()) {
+                log::warn!(
+                    "[save_manager] failed to persist metadata backfill for save {}: {}",
+                    save.id,
+                    error
+                );
+            }
         }
 
         Ok(saves)
@@ -1010,6 +1018,86 @@ mod tests {
         ];
 
         Game::new(clock, manager, vec![team], players, vec![], vec![])
+    }
+
+    #[test]
+    fn test_load_saves_backfills_legacy_index_missing_team_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let saves_dir = dir.path().join("saves");
+        let index_path = saves_dir.join("save_index.json");
+
+        let save_id = {
+            let mut sm = SaveManager::init(&saves_dir).unwrap();
+            let game = sample_game();
+            sm.create_save(&game, "Legacy Career").unwrap()
+        };
+
+        let legacy_index = format!(
+            r#"{{
+            "version": 1,
+            "saves": [{{
+                "id": "{save_id}",
+                "name": "Legacy Career",
+                "manager_name": "John Smith",
+                "db_filename": "{save_id}.db",
+                "checksum": "stale",
+                "created_at": "2026-01-01",
+                "last_played_at": "2026-01-02"
+            }}]
+        }}"#
+        );
+        fs::write(&index_path, legacy_index).unwrap();
+
+        let mut sm = SaveManager::init(&saves_dir).unwrap();
+        let saves = sm.load_saves().unwrap();
+
+        assert_eq!(saves.len(), 1);
+        assert_eq!(saves[0].team_name, "London FC");
+    }
+
+    #[test]
+    fn test_load_saves_backfills_manager_name_when_unemployed() {
+        let dir = tempfile::tempdir().unwrap();
+        let saves_dir = dir.path().join("saves");
+        let index_path = saves_dir.join("save_index.json");
+
+        let save_id = {
+            let mut sm = SaveManager::init(&saves_dir).unwrap();
+            let start = Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap();
+            let clock = GameClock::new(start);
+            let manager = domain::manager::Manager::new(
+                "mgr-user".to_string(),
+                "Jane".to_string(),
+                "Doe".to_string(),
+                "1990-01-15".to_string(),
+                "British".to_string(),
+            );
+            let game = Game::new(clock, manager, vec![], vec![], vec![], vec![]);
+            sm.create_save(&game, "Unemployed Career").unwrap()
+        };
+
+        let legacy_index = format!(
+            r#"{{
+            "version": 1,
+            "saves": [{{
+                "id": "{save_id}",
+                "name": "Unemployed Career",
+                "manager_name": "",
+                "db_filename": "{save_id}.db",
+                "checksum": "stale",
+                "created_at": "2026-01-01",
+                "last_played_at": "2026-01-02"
+            }}]
+        }}"#
+        );
+        fs::write(&index_path, legacy_index).unwrap();
+
+        let mut sm = SaveManager::init(&saves_dir).unwrap();
+        let saves = sm.load_saves().unwrap();
+
+        assert_eq!(saves.len(), 1);
+        assert_eq!(saves[0].manager_name, "Jane Doe");
+        assert_eq!(saves[0].team_name, "");
     }
 
     #[test]

--- a/src-tauri/crates/db/src/save_manager.rs
+++ b/src-tauri/crates/db/src/save_manager.rs
@@ -17,7 +17,7 @@ use ofm_core::player_rating::{
 use crate::game_database::GameDatabase;
 use crate::game_persistence::{GamePersistenceReader, GamePersistenceWriter};
 use crate::repositories::league_repo;
-use crate::save_index::{SaveEntry, compute_checksum};
+use crate::save_index::{SaveEntry, compute_checksum, save_entry_metadata_from_game};
 use crate::save_index_manager::SaveIndexManager;
 
 /// Manages save sessions: creating, loading, saving, deleting, and listing.
@@ -66,7 +66,34 @@ impl SaveManager {
 
     pub fn load_saves(&mut self) -> Result<Vec<SaveEntry>, String> {
         self.ensure_save_index_ready()?;
-        Ok(self.save_index.list_saves().to_vec())
+        let mut saves = self.save_index.list_saves().to_vec();
+        for save in saves.iter_mut() {
+            if !save.team_name.is_empty() {
+                continue;
+            }
+
+            let db_path = self.saves_dir.join(&save.db_filename);
+            let Ok(db) = GameDatabase::open(&db_path) else {
+                continue;
+            };
+            let Ok(game) = GamePersistenceReader::read_game(&db) else {
+                continue;
+            };
+
+            let (manager_name, team_name) = save_entry_metadata_from_game(&game);
+            if team_name.is_empty() && save.manager_name.is_empty() {
+                continue;
+            }
+
+            save.team_name = team_name;
+            if save.manager_name.is_empty() {
+                save.manager_name = manager_name;
+            }
+
+            self.save_index.update_save(save.clone())?;
+        }
+
+        Ok(saves)
     }
 
     /// Create a new save from the current in-memory Game state.
@@ -87,12 +114,13 @@ impl SaveManager {
 
         let checksum = compute_checksum(&db_path)?;
         let now = Utc::now().to_rfc3339();
-        let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+        let (manager_name, team_name) = save_entry_metadata_from_game(game);
 
         let entry = SaveEntry {
             id: save_id.clone(),
             name: save_name.to_string(),
             manager_name,
+            team_name,
             db_filename,
             checksum,
             created_at: now.clone(),
@@ -145,13 +173,14 @@ impl SaveManager {
         let checksum_ms = checksum_timer.elapsed().as_millis();
 
         let now = Utc::now().to_rfc3339();
-        let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+        let (manager_name, team_name) = save_entry_metadata_from_game(game);
 
         let index_timer = Instant::now();
         let entry = SaveEntry {
             id: save_id.clone(),
             name: save_name.to_string(),
             manager_name,
+            team_name,
             db_filename,
             checksum,
             created_at: now.clone(),
@@ -198,12 +227,13 @@ impl SaveManager {
 
         let checksum = compute_checksum(&db_path)?;
         let now = Utc::now().to_rfc3339();
-        let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+        let (manager_name, team_name) = save_entry_metadata_from_game(game);
 
         self.save_index.update_save(SaveEntry {
             id: save_id.to_string(),
             name: save_name,
             manager_name,
+            team_name,
             db_filename: entry.db_filename.clone(),
             checksum,
             created_at: entry.created_at.clone(),
@@ -232,6 +262,7 @@ impl SaveManager {
             id: save_id.to_string(),
             name: entry.name,
             manager_name: entry.manager_name,
+            team_name: entry.team_name.clone(),
             db_filename: entry.db_filename,
             checksum,
             created_at: entry.created_at,
@@ -283,13 +314,14 @@ impl SaveManager {
         let checksum_ms = checksum_timer.elapsed().as_millis();
 
         let now = Utc::now().to_rfc3339();
-        let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+        let (manager_name, team_name) = save_entry_metadata_from_game(game);
 
         let index_timer = Instant::now();
         self.save_index.update_save(SaveEntry {
             id: save_id.to_string(),
             name: entry.name,
             manager_name,
+            team_name,
             db_filename: entry.db_filename,
             checksum,
             created_at: entry.created_at,
@@ -419,12 +451,13 @@ impl SaveManager {
 
             let checksum = compute_checksum(&db_path)?;
             let now = Utc::now().to_rfc3339();
-            let manager_name = format!("{} {}", game.manager.first_name, game.manager.last_name);
+            let (manager_name, team_name) = save_entry_metadata_from_game(&game);
 
             self.save_index.update_save(SaveEntry {
                 id: save_id.to_string(),
                 name: save_name,
                 manager_name,
+                team_name,
                 db_filename: entry.db_filename.clone(),
                 checksum,
                 created_at: entry.created_at.clone(),
@@ -1044,6 +1077,7 @@ mod tests {
         assert_eq!(saves.len(), 1);
         assert_eq!(saves[0].name, "John's Career");
         assert_eq!(saves[0].manager_name, "John Smith");
+        assert_eq!(saves[0].team_name, "London FC");
         assert!(!saves[0].checksum.is_empty());
     }
 

--- a/src/components/menu/SavesList.tsx
+++ b/src/components/menu/SavesList.tsx
@@ -6,6 +6,7 @@ interface SaveEntry {
   id: string;
   name: string;
   manager_name: string;
+  team_name: string;
   db_filename: string;
   checksum: string;
   created_at: string;
@@ -78,7 +79,7 @@ export default function SavesList({ saves, isLoading, loadingSaveId, confirmDele
                       {loadingSaveId === save.id ? <Loader2 className="w-4 h-4 text-primary-500 animate-spin flex-shrink-0" /> : <Play className="w-4 h-4 text-primary-500 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0" />}
                     </div>
                     <div className="flex justify-between items-center w-full text-sm text-gray-500 dark:text-gray-400">
-                      <span>{t('menu.manager', { name: save.manager_name })}</span>
+                      <span>{save.team_name}</span>
                       <div className="flex items-center gap-1">
                         <Clock className="w-3 h-3" />
                         <span>{formatDate(save.last_played_at, i18n.language)}</span>

--- a/src/components/menu/SavesList.tsx
+++ b/src/components/menu/SavesList.tsx
@@ -79,7 +79,7 @@ export default function SavesList({ saves, isLoading, loadingSaveId, confirmDele
                       {loadingSaveId === save.id ? <Loader2 className="w-4 h-4 text-primary-500 animate-spin flex-shrink-0" /> : <Play className="w-4 h-4 text-primary-500 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0" />}
                     </div>
                     <div className="flex justify-between items-center w-full text-sm text-gray-500 dark:text-gray-400">
-                      <span>{save.team_name}</span>
+                      <span>{save.team_name.trim() || t('managersWorld.unemployed')}</span>
                       <div className="flex items-center gap-1">
                         <Clock className="w-3 h-3" />
                         <span>{formatDate(save.last_played_at, i18n.language)}</span>

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -29,6 +29,7 @@ interface SaveEntry {
   id: string;
   name: string;
   manager_name: string;
+  team_name: string;
   db_filename: string;
   checksum: string;
   created_at: string;


### PR DESCRIPTION
## Summary
- Add `team_name` to save index entries, populated on create/save
- Backfill `team_name` from the save DB for existing saves missing it
- Show team name on load game cards instead of `Manager: {name}`

## Motivation
With manager profile saving, users quickly accumulate multiple saves under the same manager name. The load screen repeated the manager name on every card, making it hard to tell saves apart. Team name is the useful discriminator.

Fixes #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save list now displays team information for each save (falls back to "Unemployed" when empty).

* **Refactor**
  * Save metadata extraction updated to populate manager and team names earlier.
  * Save loading now backfills missing team/manager info for legacy saves.
  * Save entries deserialize with a default empty team name for legacy data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfootmanager/openfootmanager/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->