### PR TITLE
fix(free-agents): allow signing outside transfer window and add profile action

### DIFF
--- a/src-tauri/crates/ofm_core/src/contracts.rs
+++ b/src-tauri/crates/ofm_core/src/contracts.rs
@@ -484,10 +484,6 @@ pub fn offer_free_agent_contract(
     player_id: &str,
     offer: RenewalOffer,
 ) -> Result<RenewalOutcome, String> {
-    if !transfer_window_is_open(game) {
-        return Err(ERR_TRANSFER_WINDOW_CLOSED.to_string());
-    }
-
     let manager_team_id = game
         .manager
         .team_id

--- a/src-tauri/crates/ofm_core/tests/contracts_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/contracts_tests.rs
@@ -488,6 +488,44 @@ fn free_agent_offer_rejects_lowball_terms() {
 }
 
 #[test]
+fn free_agent_can_be_signed_when_transfer_window_is_closed() {
+    let mut game = make_free_agent_game();
+    game.season_context.transfer_window.status = TransferWindowStatus::Closed;
+
+    let outcome = offer_free_agent_contract(
+        &mut game,
+        "free-agent-1",
+        RenewalOffer {
+            weekly_wage: 4_000,
+            contract_years: 3,
+        },
+    )
+    .expect("free agents should be signable outside the transfer window");
+
+    assert!(matches!(outcome.decision, RenewalDecision::Accepted));
+    assert_eq!(game.players[0].team_id.as_deref(), Some("team-1"));
+}
+
+#[test]
+fn free_agent_can_be_signed_on_deadline_day() {
+    let mut game = make_free_agent_game();
+    game.season_context.transfer_window.status = TransferWindowStatus::DeadlineDay;
+
+    let outcome = offer_free_agent_contract(
+        &mut game,
+        "free-agent-1",
+        RenewalOffer {
+            weekly_wage: 4_000,
+            contract_years: 3,
+        },
+    )
+    .expect("free agents should be signable on deadline day");
+
+    assert!(matches!(outcome.decision, RenewalDecision::Accepted));
+    assert_eq!(game.players[0].team_id.as_deref(), Some("team-1"));
+}
+
+#[test]
 fn free_agent_offer_rejects_contracts_longer_than_five_years() {
     let mut game = make_free_agent_game();
 

--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -1155,9 +1155,11 @@ describe("PlayerProfile free agent signing", () => {
     fireEvent.click(screen.getByRole("button", { name: "Submit Offer" }));
 
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("offer_free_agent_contract", expect.objectContaining({
+      expect(invoke).toHaveBeenCalledWith("offer_free_agent_contract", {
         playerId: "player-1",
-      }));
+        weeklyWage: 3000,
+        contractYears: 3,
+      });
       expect(onGameUpdate).toHaveBeenCalled();
     });
   });

--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -126,6 +126,10 @@ vi.mock("react-i18next", () => ({
       if (key === "scouting.scoutingInProgress") return "Scouting in progress";
       if (key === "scouting.scoutBtn") return "Scout";
       if (key === "finances.wagePerWeek") return "Wage/wk";
+      if (key === "transfers.offerContract") return "Offer Contract";
+      if (key === "transfers.close") return "Close";
+      if (key === "transfers.submitting") return "Submitting...";
+      if (key === "transfers.playerValue") return `Value: ${params?.value}`;
       return key;
     },
     i18n: { language: "en" },
@@ -1015,6 +1019,146 @@ describe("PlayerProfile contract surfaces", () => {
         playerId: "player-1",
       });
       expect(screen.getByText("No Contract")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("PlayerProfile free agent signing", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockImplementation(async (command: string) =>
+      defaultInvokeResponse(command),
+    );
+  });
+
+  it("shows Offer Contract button for a free agent player", () => {
+    const freeAgent = createPlayer({
+      team_id: null,
+      contract_end: null,
+      wage: 0,
+    });
+    const gameState = createGameState(freeAgent);
+
+    render(
+      <PlayerProfile
+        player={freeAgent}
+        gameState={gameState}
+        isOwnClub={false}
+        onClose={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Offer Contract" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show Offer Contract for a retired free agent", () => {
+    const retired = createPlayer({
+      team_id: null,
+      contract_end: null,
+      wage: 0,
+      retired: true,
+    });
+    const gameState = createGameState(retired);
+
+    render(
+      <PlayerProfile
+        player={retired}
+        gameState={gameState}
+        isOwnClub={false}
+        onClose={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Offer Contract" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the contract modal when Offer Contract is clicked", async () => {
+    const freeAgent = createPlayer({
+      team_id: null,
+      contract_end: null,
+      wage: 0,
+      market_value: 600_000,
+    });
+    const gameState = createGameState(freeAgent);
+
+    render(
+      <PlayerProfile
+        player={freeAgent}
+        gameState={gameState}
+        isOwnClub={false}
+        onClose={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Offer Contract" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Offer Contract" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("submits offer_free_agent_contract and updates game state on acceptance", async () => {
+    const freeAgent = createPlayer({
+      team_id: null,
+      contract_end: null,
+      wage: 0,
+      market_value: 600_000,
+    });
+    const signedPlayer = createPlayer({
+      team_id: "team-1",
+      contract_end: "2029-08-01",
+      wage: 4_000,
+    });
+    const onGameUpdate = vi.fn();
+
+    vi.mocked(invoke).mockImplementation(async (command: string) => {
+      if (command === "offer_free_agent_contract") {
+        return {
+          outcome: "accepted",
+          game: createGameState(signedPlayer),
+          suggested_wage: null,
+          suggested_years: null,
+          session_status: "agreed",
+          is_terminal: true,
+          cooled_off: false,
+          feedback: null,
+        };
+      }
+      return defaultInvokeResponse(command);
+    });
+
+    render(
+      <PlayerProfile
+        player={freeAgent}
+        gameState={createGameState(freeAgent)}
+        isOwnClub={false}
+        onClose={vi.fn()}
+        onGameUpdate={onGameUpdate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Offer Contract" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Offer Contract" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Offer" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("offer_free_agent_contract", expect.objectContaining({
+        playerId: "player-1",
+      }));
+      expect(onGameUpdate).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/playerProfile/PlayerProfile.tsx
+++ b/src/components/playerProfile/PlayerProfile.tsx
@@ -87,10 +87,6 @@ export default function PlayerProfile({
   );
   const weakFootValue = player.weak_foot ?? 2;
 
-  if (!player) {
-    return null;
-  }
-
   const [scoutStatus, setScoutStatus] = useState<PlayerProfileScoutStatus>(
     "idle",
   );

--- a/src/components/playerProfile/PlayerProfile.tsx
+++ b/src/components/playerProfile/PlayerProfile.tsx
@@ -15,6 +15,8 @@ import {
 } from "../../services/contractService";
 import DashboardModalFrame from "../dashboard/DashboardModalFrame";
 import { Button } from "../ui";
+import FreeAgentContractModal from "../transfers/FreeAgentContractModal";
+import { useFreeAgentContractFlow } from "../transfers/useFreeAgentContractFlow";
 import {
   buildPlayerAdvancedStats,
   getPlayerAge,
@@ -186,6 +188,24 @@ export default function PlayerProfile({
   const advancedStats = advancedStatsOverride ?? fallbackAdvancedStats;
   const hasLetExpireIntent =
     player.morale_core?.renewal_state?.exit_intent?.kind === "let_expire";
+  const isFreeAgent = player.team_id === null && !player.retired;
+
+  const {
+    freeAgentTarget,
+    contractWage,
+    setContractWage,
+    contractLength,
+    setContractLength,
+    contractFeedback,
+    contractProjection,
+    contractSubmitting,
+    contractSubmitDisabled,
+    contractStatusMessage,
+    contractStatusClassName,
+    openFreeAgentContract,
+    closeFreeAgentContract,
+    submitFreeAgentContract,
+  } = useFreeAgentContractFlow({ gameState, onGameUpdate });
 
   function openRenewalModal(): void {
     setRenewalWage(String(player.wage));
@@ -657,12 +677,14 @@ export default function PlayerProfile({
           contractRiskLevel={contractRiskLevel}
           contractRiskLabel={contractRiskLabel}
           isOwnClub={isOwnClub}
+          isFreeAgent={isFreeAgent}
           hasLetExpireIntent={hasLetExpireIntent}
           actionSubmitting={contractActionSubmitting}
           onOpenRenewal={openRenewalModal}
           onMarkLetExpire={() => void handleMarkLetExpire()}
           onClearLetExpire={() => void handleClearLetExpire()}
           onOpenTermination={() => void openTerminationModal()}
+          onOpenFreeAgentContract={() => openFreeAgentContract(player)}
           t={t}
         />
 
@@ -689,6 +711,25 @@ export default function PlayerProfile({
 
         <PlayerProfileRecentMatchesCard matches={recentMatches} t={t} />
       </div>
+
+      {freeAgentTarget && (
+        <FreeAgentContractModal
+          player={freeAgentTarget}
+          teams={gameState.teams}
+          wage={contractWage}
+          onWageChange={setContractWage}
+          contractLength={contractLength}
+          onContractLengthChange={setContractLength}
+          projection={contractProjection}
+          feedback={contractFeedback}
+          statusMessage={contractStatusMessage(t)}
+          statusClassName={contractStatusClassName}
+          submitting={contractSubmitting}
+          submitDisabled={contractSubmitDisabled}
+          onSubmit={submitFreeAgentContract}
+          onClose={closeFreeAgentContract}
+        />
+      )}
 
       <PlayerProfileRenewalModal
         show={showRenewalModal}

--- a/src/components/playerProfile/PlayerProfileContractCard.tsx
+++ b/src/components/playerProfile/PlayerProfileContractCard.tsx
@@ -8,6 +8,7 @@ import {
     TrendingUp,
     Trash2,
     TimerOff,
+    UserPlus,
 } from "lucide-react";
 import {
     formatDate,
@@ -35,12 +36,14 @@ interface PlayerProfileContractCardProps {
     contractRiskLevel: "critical" | "warning" | "stable";
     contractRiskLabel: string;
     isOwnClub: boolean;
+    isFreeAgent?: boolean;
     hasLetExpireIntent: boolean;
     actionSubmitting: boolean;
     onOpenRenewal: () => void;
     onMarkLetExpire: () => void;
     onClearLetExpire: () => void;
     onOpenTermination: () => void;
+    onOpenFreeAgentContract?: () => void;
     t: TranslateFn;
 }
 
@@ -57,12 +60,14 @@ export default function PlayerProfileContractCard({
     contractRiskLevel,
     contractRiskLabel,
     isOwnClub,
+    isFreeAgent,
     hasLetExpireIntent,
     actionSubmitting,
     onOpenRenewal,
     onMarkLetExpire,
     onClearLetExpire,
     onOpenTermination,
+    onOpenFreeAgentContract,
     t,
 }: PlayerProfileContractCardProps) {
     return (
@@ -160,6 +165,17 @@ export default function PlayerProfileContractCard({
                             onClick={onOpenTermination}
                         >
                             {t("playerProfile.terminateContract")}
+                        </Button>
+                    </div>
+                ) : isFreeAgent && onOpenFreeAgentContract ? (
+                    <div className="flex flex-wrap gap-2 pt-3">
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            icon={<UserPlus />}
+                            onClick={onOpenFreeAgentContract}
+                        >
+                            {t("transfers.offerContract")}
                         </Button>
                     </div>
                 ) : null}


### PR DESCRIPTION
## Summary

Fixes #160 — two related problems prevented free agents from being signed reliably:

- **Transfer window restriction**: `offer_free_agent_contract` was gating on the transfer window being open. In real football, clubs can sign free agents at any time of year. This caused a `transferWindowClosed` error for any mid-season signing attempt.
- **No profile-level action**: when navigating to a free agent's player profile (e.g. from an inbox message saying a player became a free agent), there was no way to offer a contract. The only path was the Transfer Centre table. The contract card now surfaces an **Offer Contract** button for free agents.

## Changes

### Rust (`ofm_core`)
- Removed the `transfer_window_is_open` guard from `offer_free_agent_contract`. The window check was only ever needed for paid transfers; free agents have no selling club and no registration deadline.
- Added two new tests in `contracts_tests.rs`:
  - `free_agent_can_be_signed_when_transfer_window_is_closed` — was failing before the fix
  - `free_agent_can_be_signed_on_deadline_day` — confirms deadline day still works

### Frontend
- `PlayerProfileContractCard`: accepts optional `isFreeAgent` and `onOpenFreeAgentContract` props; renders an **Offer Contract** button (with `UserPlus` icon) when the player is a free agent and the callback is provided.
- `PlayerProfile`: computes `isFreeAgent`, wires `useFreeAgentContractFlow`, passes the callback to the contract card, and renders `FreeAgentContractModal` — the same modal already used by the Transfer Centre.
- `PlayerProfile.test.tsx`: new describe block with 4 tests:
  - shows Offer Contract button for a free agent
  - hides it for a retired free agent
  - opens the modal on click
  - submits `offer_free_agent_contract` and calls `onGameUpdate` on acceptance

## Test plan

- [x] `cargo test --workspace` — 780 tests, 0 failures
- [x] `npm test` — 673/673 pass
- [x] `npm run audit:i18n` — all locales match, no new candidates
- [x] `npm run build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offer contracts to free agents from player profiles, with wage and contract-length inputs and a submission dialog.
  * "Offer Contract" button appears for eligible free agents; hidden for retired players.

* **Bug Fixes**
  * Free-agent offers can be accepted even when the season transfer window is closed or on deadline day.

* **Tests**
  * Added unit and UI tests covering the free-agent offer flow and dialog interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->