### PR TITLE
fix(match): keep chosen sim speed across the halftime break

### DIFF
--- a/src/components/match/MatchLive.tsx
+++ b/src/components/match/MatchLive.tsx
@@ -5,7 +5,6 @@ import { GameStateData } from "../../store/gameStore";
 import { MatchSnapshot, MatchEvent, MinuteResult, SimSpeed, SPEED_MS } from "./types";
 import { getEventDisplay, getPlayerName, phaseLabel } from "./helpers";
 import { Badge } from "../ui";
-import { useSettingsStore } from "../../store/settingsStore";
 import { EventFeed, MatchStats, Lineups } from "./MatchPanels";
 import MatchScreenLayout from "./MatchScreenLayout";
 import { SubPanel } from "./SubPanel";
@@ -24,6 +23,10 @@ interface MatchLiveProps {
   userSide: "Home" | "Away" | null;
   isSpectator: boolean;
   importantEvents: MatchEvent[];
+  // Chosen sim speed, owned by the parent so it persists across the halftime
+  // remount (issue #106). onSpeedChange reports user-selected speeds back up.
+  speed: SimSpeed;
+  onSpeedChange: (next: SimSpeed) => void;
   onSnapshotUpdate: (snap: MatchSnapshot) => void;
   onImportantEvent: (evt: MatchEvent) => void;
   onHalfTime: () => void;
@@ -32,12 +35,11 @@ interface MatchLiveProps {
 
 export default function MatchLive({
   snapshot, gameState, userSide, isSpectator,
-  importantEvents, onSnapshotUpdate, onImportantEvent,
+  importantEvents, speed: initialSpeed, onSpeedChange,
+  onSnapshotUpdate, onImportantEvent,
   onHalfTime, onFullTime,
 }: MatchLiveProps) {
   const { t } = useTranslation();
-  const { settings } = useSettingsStore();
-  const initialSpeed: SimSpeed = (settings.match_speed === "slow" || settings.match_speed === "fast") ? settings.match_speed : "normal";
   const [speed, setSpeed] = useState<SimSpeed>(initialSpeed);
   const [activePanel, setActivePanel] = useState<ActivePanel>("events");
   const [isRunning, setIsRunning] = useState(true);
@@ -305,7 +307,14 @@ export default function MatchLive({
               ]).map(s => (
                 <button
                   key={s.id}
-                  onClick={() => { setSpeed(s.id); setIsRunning(s.id !== "paused"); }}
+                  onClick={() => {
+                    setSpeed(s.id);
+                    setIsRunning(s.id !== "paused");
+                    // Persist the chosen rate in the parent so it survives the
+                    // halftime remount. A manual pause stays local so resuming
+                    // keeps the last real speed (issue #106).
+                    if (s.id !== "paused") onSpeedChange(s.id);
+                  }}
                   className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg text-xs font-heading uppercase tracking-wider transition-all ${speed === s.id ? "bg-primary-500/20 text-primary-500 dark:text-primary-400 ring-1 ring-primary-500/50" : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-navy-700"
                     }`}
                 >

--- a/src/pages/MatchSimulation.test.tsx
+++ b/src/pages/MatchSimulation.test.tsx
@@ -32,28 +32,59 @@ vi.mock("../store/gameStore", () => ({
   useGameStore: () => gameStoreState,
 }));
 
+vi.mock("../store/settingsStore", () => ({
+  useSettingsStore: () => ({ settings: { match_speed: "normal" } }),
+}));
+
 vi.mock("../components/match/PreMatchSetup", () => ({
-  default: ({ snapshot }: { snapshot: { home_team: { name: string } } }) => (
-    <div data-testid="prematch">{snapshot.home_team.name}</div>
+  default: ({
+    snapshot,
+    onStart,
+  }: {
+    snapshot: { home_team: { name: string } };
+    onStart?: () => void;
+  }) => (
+    <div data-testid="prematch">
+      {snapshot.home_team.name}
+      <button data-testid="prematch-start" onClick={onStart} />
+    </div>
   ),
 }));
 
 vi.mock("../components/match/MatchLive", () => ({
   default: ({
     snapshot,
+    speed,
+    onSpeedChange,
+    onHalfTime,
     onFullTime,
   }: {
     snapshot: { home_team: { name: string } };
+    speed?: string;
+    onSpeedChange?: (next: string) => void;
+    onHalfTime?: () => void;
     onFullTime?: () => void;
   }) => (
-    <button data-testid="match-live" onClick={onFullTime}>
-      {snapshot.home_team.name}
-    </button>
+    <div>
+      <button data-testid="match-live" onClick={onFullTime}>
+        {snapshot.home_team.name}
+      </button>
+      <span data-testid="match-live-speed">{speed}</span>
+      <button
+        data-testid="match-live-set-fast"
+        onClick={() => onSpeedChange?.("fast")}
+      />
+      <button data-testid="match-live-halftime" onClick={onHalfTime} />
+    </div>
   ),
 }));
 
 vi.mock("../components/match/HalfTimeBreak", () => ({
-  default: () => <div data-testid="halftime" />,
+  default: ({ onResume }: { onResume?: () => void }) => (
+    <div data-testid="halftime">
+      <button data-testid="halftime-resume" onClick={onResume} />
+    </div>
+  ),
 }));
 
 vi.mock("../components/match/PostMatchScreen", () => ({
@@ -387,6 +418,41 @@ describe("MatchSimulation", function (): void {
     await waitFor(function (): void {
       expect(navigateMock).toHaveBeenCalledWith("/dashboard");
     });
+  });
+
+  it("keeps the chosen match speed when resuming from halftime", async function (): Promise<void> {
+    mockedInvoke.mockResolvedValue(makeSnapshot());
+
+    render(<MatchSimulation />);
+
+    // Pre-match, then kick off into the first half.
+    await waitFor(function (): void {
+      expect(screen.getByTestId("prematch-start")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("prematch-start"));
+
+    // First half starts at the settings default speed.
+    await waitFor(function (): void {
+      expect(screen.getByTestId("match-live")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("match-live-speed")).toHaveTextContent("normal");
+
+    // User speeds the match up.
+    fireEvent.click(screen.getByTestId("match-live-set-fast"));
+    expect(screen.getByTestId("match-live-speed")).toHaveTextContent("fast");
+
+    // Go to halftime, then resume into the second half.
+    fireEvent.click(screen.getByTestId("match-live-halftime"));
+    await waitFor(function (): void {
+      expect(screen.getByTestId("halftime")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("halftime-resume"));
+
+    // Second half must keep the user's chosen speed, not reset to the default.
+    await waitFor(function (): void {
+      expect(screen.getByTestId("match-live")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("match-live-speed")).toHaveTextContent("fast");
   });
 
   it("finalizes the match on full time and passes the round summary into postmatch", async function (): Promise<void> {

--- a/src/pages/MatchSimulation.tsx
+++ b/src/pages/MatchSimulation.tsx
@@ -3,11 +3,13 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
 import { useGameStore, GameStateData } from "../store/gameStore";
+import { useSettingsStore } from "../store/settingsStore";
 import {
   MatchSnapshot,
   MatchEvent,
   MatchDayStage,
   RoundSummary,
+  SimSpeed,
 } from "../components/match/types";
 import { resolveMatchFixture } from "../components/match/helpers";
 import PreMatchSetup from "../components/match/PreMatchSetup";
@@ -38,10 +40,19 @@ export default function MatchSimulation() {
   const routeState = (location.state as MatchRouteState | null) ?? null;
   const matchMode = routeState?.mode || "live";
   const { gameState, setGameState } = useGameStore();
+  const { settings } = useSettingsStore();
   const [snapshot, setSnapshot] = useState<MatchSnapshot | null>(
     routeState?.snapshot ?? null,
   );
   const [stage, setStage] = useState<MatchDayStage>("prematch");
+  // The chosen match speed lives here so it survives the MatchLive remount that
+  // happens across the halftime break (issue #106). MatchLive reports user speed
+  // changes back up, but keeps its own auto-pause local.
+  const [matchSpeed, setMatchSpeed] = useState<SimSpeed>(
+    settings.match_speed === "slow" || settings.match_speed === "fast"
+      ? settings.match_speed
+      : "normal",
+  );
   const [importantEvents, setImportantEvents] = useState<MatchEvent[]>([]);
   const [userSide, setUserSide] = useState<"Home" | "Away" | null>(null);
   const [isSpectator, setIsSpectator] = useState(matchMode === "spectator");
@@ -299,6 +310,8 @@ export default function MatchSimulation() {
           userSide={userSide}
           isSpectator={isSpectator}
           importantEvents={importantEvents}
+          speed={matchSpeed}
+          onSpeedChange={setMatchSpeed}
           onSnapshotUpdate={handleSnapshotUpdate}
           onImportantEvent={handleImportantEvent}
           onHalfTime={handleHalfTime}


### PR DESCRIPTION
## Issue

Fixes #106 — "Velocidade de jogo alterando sozinha". The sim speed the user picks in the first half is silently lost after halftime; the second half runs at the settings default instead.

## Root cause

`MatchSimulation` renders the match day as a stage machine. The `halftime` stage swaps `MatchLive` out for `HalfTimeBreak`, and `<MatchLive key={stage} />` also differs between `first_half` and `second_half`. Either way the second half gets a **fresh** `MatchLive`, whose local `speed` state re-initialized from the settings store and discarded the user's choice.

## Fix

Lift the chosen speed into `MatchSimulation` so it survives the remount:

- `MatchSimulation` owns `matchSpeed` (initialized from the settings store) and passes `speed` + `onSpeedChange` to `MatchLive`.
- `MatchLive` initializes its local `speed` from the prop and reports user-selected rates back up.
- Manual pause and the automatic pause at phase transitions stay local (they don't call `onSpeedChange`), so resuming keeps the last real speed instead of coming back paused.

Only the bug changes; all other match behavior is identical.

## Tests

Added a test in `MatchSimulation.test.tsx`: set speed to "fast" in the first half, go to halftime, resume, and assert the second half keeps "fast".

## Gates

- `npx tsc --noEmit` clean
- `npm run audit:i18n` exit 0 (no new user-facing strings)
- `npx vitest run` 668/668 pass
- `npm run build` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed simulation speed resetting to default when resuming from halftime. Selected playback speed now persists throughout the entire match simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->