### PR TITLE
feat: support generic world media paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage/
 
 # Local Vitest reporter output
 vitest-*.json
+
+# Personal-use imported world assets/data
+/public/assets/worlds/

--- a/src-tauri/crates/db/src/migrations.rs
+++ b/src-tauri/crates/db/src/migrations.rs
@@ -1,7 +1,7 @@
 use rusqlite_migration::{M, Migrations};
 
 /// Number of migrations defined. Keep in sync with the vec in `all_migrations`.
-pub const MIGRATION_COUNT: usize = 27;
+pub const MIGRATION_COUNT: usize = 28;
 
 /// All migrations for a per-save game database.
 /// Each save `.db` file gets this schema applied via `rusqlite_migration`.
@@ -61,6 +61,8 @@ pub fn all_migrations() -> Migrations<'static> {
         M::up(include_str!("sql/v026_world_history_archive.sql")),
         // V27: Persist available staff market activity for monthly rotation
         M::up(include_str!("sql/v027_available_staff_market_activity.sql")),
+        // V28: Persist optional local media paths for teams and players
+        M::up(include_str!("sql/v028_entity_media.sql")),
     ])
 }
 
@@ -151,6 +153,30 @@ mod tests {
         assert!(
             game_meta_columns.contains(&"available_staff_market_last_activity_date".to_string()),
             "missing game_meta.available_staff_market_last_activity_date"
+        );
+
+        let team_columns: Vec<String> = conn
+            .prepare("PRAGMA table_info(teams)")
+            .unwrap()
+            .query_map([], |row| row.get(1))
+            .unwrap()
+            .filter_map(|row| row.ok())
+            .collect();
+        assert!(
+            team_columns.contains(&"media_json".to_string()),
+            "missing teams.media_json"
+        );
+
+        let player_columns: Vec<String> = conn
+            .prepare("PRAGMA table_info(players)")
+            .unwrap()
+            .query_map([], |row| row.get(1))
+            .unwrap()
+            .filter_map(|row| row.ok())
+            .collect();
+        assert!(
+            player_columns.contains(&"media_json".to_string()),
+            "missing players.media_json"
         );
     }
 

--- a/src-tauri/crates/db/src/repositories/player_repo.rs
+++ b/src-tauri/crates/db/src/repositories/player_repo.rs
@@ -1,4 +1,4 @@
-use domain::player::{Footedness, Player, PlayerAttributes, Position, SquadRole};
+use domain::player::{Footedness, Player, PlayerAttributes, PlayerMedia, Position, SquadRole};
 use domain::team::TrainingFocus;
 use rusqlite::{Connection, params};
 
@@ -23,6 +23,8 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
         .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
     let morale_core_json = serde_json::to_string(&p.morale_core)
         .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
+    let media_json = serde_json::to_string(&p.media)
+        .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
     let position_str = format!("{:?}", p.position);
     let natural_position_str = format!("{:?}", p.natural_position);
     let alt_positions_json = serde_json::to_string(&p.alternate_positions)
@@ -37,8 +39,8 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
           contract_end, wage, market_value, stats, career,
           transfer_listed, loan_listed, transfer_offers, alternate_positions,
           natural_position, training_focus, morale_core, footedness, weak_foot, fitness, squad_role,
-          ovr, potential)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33)",
+          ovr, potential, media_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34)",
         params![
             p.id,
             p.match_name,
@@ -73,6 +75,7 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
             format!("{:?}", p.squad_role),
             p.ovr as i64,
             p.potential as i64,
+            media_json,
         ],
     )
     .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
@@ -146,7 +149,7 @@ pub fn load_all_players(conn: &Connection) -> Result<Vec<Player>, String> {
                     contract_end, wage, market_value, stats, career,
                     transfer_listed, loan_listed, transfer_offers, alternate_positions,
                     natural_position, training_focus, morale_core, footedness, weak_foot, fitness, squad_role,
-                    ovr, potential
+                    ovr, potential, COALESCE(media_json, '{}')
              FROM players",
         )
         .map_err(|_| GAME_PERSISTENCE_LOAD_ERROR.to_string())?;
@@ -171,7 +174,7 @@ pub fn load_players_by_team(conn: &Connection, team_id: &str) -> Result<Vec<Play
                     contract_end, wage, market_value, stats, career,
                     transfer_listed, loan_listed, transfer_offers, alternate_positions,
                     natural_position, training_focus, morale_core, footedness, weak_foot, fitness, squad_role,
-                    ovr, potential
+                    ovr, potential, COALESCE(media_json, '{}')
              FROM players WHERE team_id = ?1",
         )
         .map_err(|_| GAME_PERSISTENCE_LOAD_ERROR.to_string())?;
@@ -206,6 +209,7 @@ fn row_to_player(row: &rusqlite::Row) -> rusqlite::Result<Player> {
     let squad_role_str: String = row.get(30).unwrap_or_else(|_| "Senior".to_string());
     let ovr: u8 = row.get::<_, i64>(31).unwrap_or(0) as u8; // default 0 for saves before V20
     let potential: u8 = row.get::<_, i64>(32).unwrap_or(0) as u8; // default 0 for saves before V20
+    let media_json: String = row.get(33).unwrap_or_else(|_| "{}".to_string());
     let transfer_listed_int: i32 = row.get(20)?;
     let loan_listed_int: i32 = row.get(21)?;
     let market_value_i64: i64 = row.get(17)?;
@@ -225,6 +229,7 @@ fn row_to_player(row: &rusqlite::Row) -> rusqlite::Result<Player> {
         nationality: row.get(4)?,
         football_nation: row.get(5)?,
         birth_country: row.get(6)?,
+        media: serde_json::from_str(&media_json).unwrap_or_else(|_| PlayerMedia::default()),
         position,
         natural_position,
         alternate_positions: serde_json::from_str(&alt_positions_json).unwrap_or_default(),
@@ -355,6 +360,25 @@ mod tests {
     }
 
     #[test]
+    fn test_player_media_face_roundtrip() {
+        let db = test_db();
+        let mut player = sample_player("p-media", Some("team-001"));
+        player.media.face = Some("/assets/worlds/test-world/players/p-media.png".to_string());
+
+        upsert_player(db.conn(), &player).unwrap();
+        let loaded = load_all_players(db.conn()).unwrap();
+        let stored = loaded
+            .iter()
+            .find(|candidate| candidate.id == "p-media")
+            .expect("stored player should exist");
+
+        assert_eq!(
+            stored.media.face.as_deref(),
+            Some("/assets/worlds/test-world/players/p-media.png")
+        );
+    }
+
+    #[test]
     fn test_player_squad_role_roundtrip() {
         let db = test_db();
         let mut player = sample_player("p-youth", Some("team-001"));
@@ -401,8 +425,10 @@ mod tests {
     #[test]
     fn test_load_players_by_team() {
         let db = test_db();
+        let mut media_player = sample_player("p-001", Some("team-001"));
+        media_player.media.face = Some("/assets/worlds/test-world/players/p-001.png".to_string());
         let players = vec![
-            sample_player("p-001", Some("team-001")),
+            media_player,
             sample_player("p-002", Some("team-001")),
             sample_player("p-003", Some("team-002")),
         ];
@@ -410,6 +436,16 @@ mod tests {
 
         let team1 = load_players_by_team(db.conn(), "team-001").unwrap();
         assert_eq!(team1.len(), 2);
+        assert_eq!(
+            team1
+                .iter()
+                .find(|player| player.id == "p-001")
+                .unwrap()
+                .media
+                .face
+                .as_deref(),
+            Some("/assets/worlds/test-world/players/p-001.png")
+        );
 
         let team2 = load_players_by_team(db.conn(), "team-002").unwrap();
         assert_eq!(team2.len(), 1);

--- a/src-tauri/crates/db/src/repositories/team_repo.rs
+++ b/src-tauri/crates/db/src/repositories/team_repo.rs
@@ -1,6 +1,6 @@
 use domain::team::{
-    Facilities, FinancialTransaction, PlayStyle, Sponsorship, Team, TeamColors, TrainingFocus,
-    TrainingIntensity, TrainingSchedule,
+    Facilities, FinancialTransaction, PlayStyle, Sponsorship, Team, TeamColors, TeamMedia,
+    TrainingFocus, TrainingIntensity, TrainingSchedule,
 };
 use rusqlite::{Connection, params};
 
@@ -25,6 +25,8 @@ pub fn upsert_team(conn: &Connection, t: &Team) -> Result<(), String> {
         .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
     let facilities_json = serde_json::to_string(&t.facilities)
         .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
+    let media_json = serde_json::to_string(&t.media)
+        .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
     let play_style_str = format!("{:?}", t.play_style);
     let training_focus_str = format!("{:?}", t.training_focus);
     let training_intensity_str = format!("{:?}", t.training_intensity);
@@ -37,8 +39,8 @@ pub fn upsert_team(conn: &Connection, t: &Team) -> Result<(), String> {
          season_income, season_expenses, formation, play_style,
          training_focus, training_intensity, training_schedule,
          founded_year, colors_primary, colors_secondary,
-         starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)",
+         starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities, media_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)",
         params![
             t.id,
             t.name,
@@ -71,6 +73,7 @@ pub fn upsert_team(conn: &Connection, t: &Team) -> Result<(), String> {
             financial_ledger_json,
             sponsorship_json,
             facilities_json,
+            media_json,
         ],
     )
     .map_err(|_| GAME_PERSISTENCE_WRITE_ERROR.to_string())?;
@@ -136,6 +139,7 @@ fn row_to_team(row: &rusqlite::Row) -> rusqlite::Result<Team> {
     let training_focus_str: String = row.get(17)?;
     let training_intensity_str: String = row.get(18)?;
     let training_schedule_str: String = row.get(19)?;
+    let media_json: String = row.get(31).unwrap_or_else(|_| "{}".to_string());
 
     Ok(Team {
         id: row.get(0)?,
@@ -169,6 +173,7 @@ fn row_to_team(row: &rusqlite::Row) -> rusqlite::Result<Team> {
             primary: row.get(21)?,
             secondary: row.get(22)?,
         },
+        media: serde_json::from_str(&media_json).unwrap_or_else(|_| TeamMedia::default()),
         starting_xi_ids: serde_json::from_str(&starting_xi_json).unwrap_or_default(),
         match_roles: serde_json::from_str(&match_roles_json).unwrap_or_default(),
         form: serde_json::from_str(&form_json).unwrap_or_default(),
@@ -185,7 +190,8 @@ pub fn load_all_teams(conn: &Connection) -> Result<Vec<Team>, String> {
                     season_income, season_expenses, formation, play_style,
                     training_focus, training_intensity, training_schedule,
                     founded_year, colors_primary, colors_secondary,
-                    starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities
+                    starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities,
+                    COALESCE(media_json, '{}')
              FROM teams",
         )
         .map_err(|_| GAME_PERSISTENCE_LOAD_ERROR.to_string())?;
@@ -210,7 +216,8 @@ pub fn load_team(conn: &Connection, id: &str) -> Result<Option<Team>, String> {
                     season_income, season_expenses, formation, play_style,
                     training_focus, training_intensity, training_schedule,
                     founded_year, colors_primary, colors_secondary,
-                    starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities
+                    starting_xi_ids, match_roles, form, history, training_groups, financial_ledger, sponsorship, facilities,
+                    COALESCE(media_json, '{}')
              FROM teams WHERE id = ?1",
         )
         .map_err(|_| GAME_PERSISTENCE_LOAD_ERROR.to_string())?;
@@ -306,6 +313,21 @@ mod tests {
 
         assert_eq!(loaded.colors.primary, "#ff0000");
         assert_eq!(loaded.colors.secondary, "#00ff00");
+    }
+
+    #[test]
+    fn test_team_media_logo_roundtrip() {
+        let db = test_db();
+        let mut team = sample_team("team-media", "Media FC");
+        team.media.logo = Some("/assets/worlds/test-world/teams/team-media.png".to_string());
+
+        upsert_team(db.conn(), &team).unwrap();
+        let loaded = load_team(db.conn(), "team-media").unwrap().unwrap();
+
+        assert_eq!(
+            loaded.media.logo.as_deref(),
+            Some("/assets/worlds/test-world/teams/team-media.png")
+        );
     }
 
     #[test]

--- a/src-tauri/crates/db/src/sql/v028_entity_media.sql
+++ b/src-tauri/crates/db/src/sql/v028_entity_media.sql
@@ -1,0 +1,2 @@
+ALTER TABLE teams ADD COLUMN media_json TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE players ADD COLUMN media_json TEXT NOT NULL DEFAULT '{}';

--- a/src-tauri/crates/domain/src/player.rs
+++ b/src-tauri/crates/domain/src/player.rs
@@ -11,6 +11,8 @@ pub struct Player {
     pub football_nation: String,
     #[serde(default)]
     pub birth_country: Option<String>,
+    #[serde(default)]
+    pub media: PlayerMedia,
 
     pub position: Position,
 
@@ -82,6 +84,12 @@ pub struct Player {
     pub transfer_offers: Vec<TransferOffer>,
     #[serde(default)]
     pub morale_core: PlayerMoraleCore,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PlayerMedia {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub face: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
@@ -536,6 +544,7 @@ impl Player {
             nationality,
             football_nation,
             birth_country,
+            media: PlayerMedia::default(),
             natural_position: position.clone(),
             position,
             alternate_positions: Vec::new(),

--- a/src-tauri/crates/domain/src/team.rs
+++ b/src-tauri/crates/domain/src/team.rs
@@ -44,6 +44,8 @@ pub struct Team {
     // Club info
     pub founded_year: u32,
     pub colors: TeamColors,
+    #[serde(default)]
+    pub media: TeamMedia,
 
     // Training groups: allow per-group focus overrides for subsets of players
     #[serde(default)]
@@ -143,6 +145,12 @@ pub struct TrainingGroup {
 pub struct TeamColors {
     pub primary: String,
     pub secondary: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TeamMedia {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logo: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -281,6 +289,7 @@ impl Team {
                 primary: "#10b981".to_string(),
                 secondary: "#ffffff".to_string(),
             },
+            media: TeamMedia::default(),
             starting_xi_ids: Vec::new(),
             match_roles: MatchRoles::default(),
             form: Vec::new(),

--- a/src-tauri/databases/README.md
+++ b/src-tauri/databases/README.md
@@ -15,3 +15,30 @@ Place `.json` world database files here to make them available when creating a n
 ```
 
 You can export a world database from an existing game using the in-game export feature.
+
+## Optional media paths
+
+Teams and players can include optional local media paths. These paths are generic and dataset-defined; the game does not infer provider-specific URLs or require numeric IDs.
+
+```json
+{
+  "teams": [
+    {
+      "id": "team-id",
+      "media": {
+        "logo": "/assets/worlds/my-world/teams/team-id.png"
+      }
+    }
+  ],
+  "players": [
+    {
+      "id": "player-id",
+      "media": {
+        "face": "/assets/worlds/my-world/players/player-id.png"
+      }
+    }
+  ]
+}
+```
+
+Put matching files under `public/assets/worlds/<world-id>/...` for development builds. Missing images fall back to text initials/short names.

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -18,7 +18,7 @@ import {
   buildViewProfileMenuItem,
   buildViewTeamMenuItem,
 } from "../playerActions/playerContextMenuItems";
-import { Badge, ThemeToggle } from "../ui";
+import { Badge, PlayerAvatar, TeamLogo, ThemeToggle } from "../ui";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
 import { getPlayerBadgeVariant } from "./dashboardHelpers";
 
@@ -210,12 +210,13 @@ function renderSearchResults(props: {
                   className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-navy-600"
                   data-testid={`dashboard-search-team-${team.id}`}
                 >
-                  <div
-                    className="flex h-6 w-6 items-center justify-center rounded text-xs font-bold text-white"
+                  <TeamLogo
+                    team={team}
+                    className="flex h-6 w-6 items-center justify-center overflow-hidden rounded text-xs font-bold text-white"
+                    imageClassName="h-5 w-5 object-contain"
+                    fallback={<span>{team.short_name.charAt(0)}</span>}
                     style={{ backgroundColor: team.colors.primary }}
-                  >
-                    {team.short_name.charAt(0)}
-                  </div>
+                  />
                   <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
                     {team.name}
                   </span>
@@ -249,6 +250,10 @@ function renderSearchResults(props: {
                   className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-navy-600"
                   data-testid={`dashboard-search-player-${player.id}`}
                 >
+                  <PlayerAvatar
+                    player={player}
+                    className="h-7 w-7 shrink-0 overflow-hidden rounded bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-[10px] font-heading font-bold text-gray-500 dark:text-gray-300"
+                  />
                   <Badge variant={getPlayerBadgeVariant(player.position)} size="sm">
                     {translatePositionAbbreviation(t, player.position)}
                   </Badge>

--- a/src/components/hallOfFame/HallOfFameWorldTab.tsx
+++ b/src/components/hallOfFame/HallOfFameWorldTab.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import type { GameStateData } from "../../store/gameStore";
 import { countryName } from "../../lib/countries";
-import { Badge, Card, CardBody, CardHeader, CountryFlag } from "../ui";
+import { Badge, Card, CardBody, CardHeader, CountryFlag, TeamLogo } from "../ui";
 import {
   deriveHallOfFameLegends,
   derivePastChampions,
@@ -175,23 +175,31 @@ export default function HallOfFameWorldTab({
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-3 text-sm md:min-w-[16rem]">
-                    <StatTile
-                      label={t("hallOfFameWorld.played")}
-                      value={champion.record.played.toString()}
+                  <div className="flex items-center gap-4">
+                    <TeamLogo
+                      team={champion.team}
+                      className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-accent-100 dark:bg-accent-900/40 flex items-center justify-center text-sm font-heading font-bold text-accent-700 dark:text-accent-300"
+                      imageClassName="h-11 w-11 object-contain drop-shadow"
+                      fallback={<span>{champion.team.short_name.charAt(0)}</span>}
                     />
-                    <StatTile
-                      label={t("hallOfFameWorld.goals")}
-                      value={champion.record.goals_for.toString()}
-                    />
-                    <StatTile
-                      label={t("hallOfFameWorld.record")}
-                      value={`${champion.record.won}-${champion.record.drawn}-${champion.record.lost}`}
-                    />
-                    <StatTile
-                      label={t("hallOfFameWorld.goalDifference")}
-                      value={(champion.record.goals_for - champion.record.goals_against).toString()}
-                    />
+                    <div className="grid grid-cols-2 gap-3 text-sm md:min-w-[16rem]">
+                      <StatTile
+                        label={t("hallOfFameWorld.played")}
+                        value={champion.record.played.toString()}
+                      />
+                      <StatTile
+                        label={t("hallOfFameWorld.goals")}
+                        value={champion.record.goals_for.toString()}
+                      />
+                      <StatTile
+                        label={t("hallOfFameWorld.record")}
+                        value={`${champion.record.won}-${champion.record.drawn}-${champion.record.lost}`}
+                      />
+                      <StatTile
+                        label={t("hallOfFameWorld.goalDifference")}
+                        value={(champion.record.goals_for - champion.record.goals_against).toString()}
+                      />
+                    </div>
                   </div>
                 </CardBody>
               </Card>

--- a/src/components/home/HomeNextOpponentCard.tsx
+++ b/src/components/home/HomeNextOpponentCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import { formatDateShort } from "../../lib/helpers";
-import { Badge, Card, CardBody, CardHeader } from "../ui";
+import { Badge, Card, CardBody, CardHeader, TeamLogo } from "../ui";
 import type { NextOpponentWidgetData } from "./HomeTab.helpers";
 
 interface HomeNextOpponentCardProps {
@@ -46,13 +46,20 @@ export default function HomeNextOpponentCard({
 
               return (
                 <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-lg font-heading font-bold text-gray-800 dark:text-gray-100 truncate">
-                      {nextOpponent.opponent.name}
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      {fixtureLabel} - {formatDateShort(nextOpponent.fixture.date, lang)}
-                    </p>
+                  <div className="min-w-0 flex items-center gap-3">
+                    <TeamLogo
+                      team={nextOpponent.opponent}
+                      className="h-11 w-11 shrink-0 overflow-hidden rounded-lg bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-xs font-heading font-bold text-gray-500 dark:text-gray-300"
+                      imageClassName="h-9 w-9 object-contain drop-shadow"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-lg font-heading font-bold text-gray-800 dark:text-gray-100 truncate">
+                        {nextOpponent.opponent.name}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        {fixtureLabel} - {formatDateShort(nextOpponent.fixture.date, lang)}
+                      </p>
+                    </div>
                   </div>
                   <Badge
                     variant={nextOpponent.isHome ? "success" : "accent"}

--- a/src/components/home/HomePlayerMomentumCard.tsx
+++ b/src/components/home/HomePlayerMomentumCard.tsx
@@ -2,7 +2,7 @@ import { TrendingDown, TrendingUp } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerData } from "../../store/gameStore";
-import { Badge, Card, CardBody, CardHeader } from "../ui";
+import { Badge, Card, CardBody, CardHeader, PlayerAvatar } from "../ui";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
 
 interface HomePlayerMomentumCardProps {
@@ -52,6 +52,7 @@ export default function HomePlayerMomentumCard({
                     key={player.id}
                     className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-green-500/5 dark:bg-green-500/10"
                   >
+                    <PlayerAvatar player={player} className="h-7 w-7 shrink-0 overflow-hidden rounded bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-[10px] font-heading font-bold text-gray-500 dark:text-gray-300" />
                     <span className="text-xs font-medium text-gray-800 dark:text-gray-200 flex-1 truncate">
                       {player.full_name}
                     </span>
@@ -80,6 +81,7 @@ export default function HomePlayerMomentumCard({
                     key={player.id}
                     className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-red-500/5 dark:bg-red-500/10"
                   >
+                    <PlayerAvatar player={player} className="h-7 w-7 shrink-0 overflow-hidden rounded bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-[10px] font-heading font-bold text-gray-500 dark:text-gray-300" />
                     <span className="text-xs font-medium text-gray-800 dark:text-gray-200 flex-1 truncate">
                       {player.full_name}
                     </span>

--- a/src/components/home/HomeRecentResultsCard.tsx
+++ b/src/components/home/HomeRecentResultsCard.tsx
@@ -1,8 +1,8 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { getTeamName } from "../../lib/helpers";
 import type { TeamData } from "../../store/gameStore";
-import { Card, CardBody, CardHeader } from "../ui";
+import { Card, CardBody, CardHeader, TeamLogo } from "../ui";
 import type { HomeRecentResult } from "./HomeTab.helpers";
 
 interface HomeRecentResultsCardProps {
@@ -17,6 +17,10 @@ export default function HomeRecentResultsCard({
   onNavigate,
 }: HomeRecentResultsCardProps) {
   const { t } = useTranslation();
+  const teamsById = useMemo(
+    () => new Map(teams.map((team) => [team.id, team])),
+    [teams],
+  );
 
   return (
     <Card>
@@ -42,33 +46,44 @@ export default function HomeRecentResultsCard({
             {recentResults
               .slice(-5)
               .reverse()
-              .map((result) => (
-                <div
-                  key={result.fixture.id}
-                  className="flex items-center px-4 py-2.5 gap-3"
-                >
-                  <span
-                    className={`w-5 h-5 rounded flex items-center justify-center text-[9px] font-heading font-bold text-white flex-shrink-0 ${
-                      result.resultCode === "W"
-                        ? "bg-green-500"
-                        : result.resultCode === "L"
-                          ? "bg-red-500"
-                          : "bg-gray-400"
-                    }`}
+              .map((result) => {
+                const opponent = teamsById.get(result.opponentId);
+
+                return (
+                  <div
+                    key={result.fixture.id}
+                    className="flex items-center px-4 py-2.5 gap-3"
                   >
-                    {result.resultCode}
-                  </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 w-6">
-                    {result.isHome ? t("home.home").charAt(0) : t("home.away").charAt(0)}
-                  </span>
-                  <span className="text-sm font-medium text-gray-800 dark:text-gray-200 flex-1 truncate">
-                    {getTeamName(teams, result.opponentId)}
-                  </span>
-                  <span className="text-sm font-heading font-bold text-gray-700 dark:text-gray-300 tabular-nums">
-                    {result.myGoals} - {result.opponentGoals}
-                  </span>
-                </div>
-              ))}
+                    <span
+                      className={`w-5 h-5 rounded flex items-center justify-center text-[9px] font-heading font-bold text-white flex-shrink-0 ${
+                        result.resultCode === "W"
+                          ? "bg-green-500"
+                          : result.resultCode === "L"
+                            ? "bg-red-500"
+                            : "bg-gray-400"
+                      }`}
+                    >
+                      {result.resultCode}
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 w-6">
+                      {result.isHome ? t("home.home").charAt(0) : t("home.away").charAt(0)}
+                    </span>
+                    {opponent ? (
+                      <TeamLogo
+                        team={opponent}
+                        className="h-7 w-7 shrink-0 overflow-hidden rounded bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-[10px] font-heading font-bold text-gray-500 dark:text-gray-300"
+                        imageClassName="h-5 w-5 object-contain drop-shadow"
+                      />
+                    ) : null}
+                    <span className="text-sm font-medium text-gray-800 dark:text-gray-200 flex-1 truncate">
+                      {opponent?.name ?? t("common.unknown")}
+                    </span>
+                    <span className="text-sm font-heading font-bold text-gray-700 dark:text-gray-300 tabular-nums">
+                      {result.myGoals} - {result.opponentGoals}
+                    </span>
+                  </div>
+                );
+              })}
           </div>
         )}
       </CardBody>

--- a/src/components/home/HomeUnavailablePlayersCard.tsx
+++ b/src/components/home/HomeUnavailablePlayersCard.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerData } from "../../store/gameStore";
-import { Badge, Card, CardBody, CardHeader } from "../ui";
+import { Badge, Card, CardBody, CardHeader, PlayerAvatar } from "../ui";
 
 interface HomeUnavailablePlayersCardProps {
   players: PlayerData[];
@@ -45,20 +45,24 @@ export default function HomeUnavailablePlayersCard({
               key={player.id}
               className="flex flex-col gap-2 rounded-lg border border-gray-100 px-3 py-2.5 dark:border-navy-700 sm:flex-row sm:items-center sm:justify-between"
             >
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="truncate text-sm font-heading font-bold text-gray-800 dark:text-gray-200">
-                    {player.full_name}
-                  </span>
-                  <Badge variant="danger" size="sm">
-                    {t("common.injured")}
-                  </Badge>
+              <div className="min-w-0 flex items-center gap-3">
+                <PlayerAvatar player={player} />
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-heading font-bold text-gray-800 dark:text-gray-200">
+                      {player.full_name}
+                    </span>
+                    <Badge variant="danger" size="sm">
+                      {t("common.injured")}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {player.injury ? `${resolveInjuryName(player.injury.name)} - ` : ""}
+                    {t("home.daysUnavailable", {
+                      count: player.injury?.days_remaining ?? 0,
+                    })}
+                  </p>
                 </div>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {player.injury ? resolveInjuryName(player.injury.name) : ""} - {t("home.daysUnavailable", {
-                    count: player.injury?.days_remaining ?? 0,
-                  })}
-                </p>
               </div>
               <div className="text-xs font-heading font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">
                 {t(`common.positions.${player.position}`, {

--- a/src/components/match/HalfTimeBreak.tsx
+++ b/src/components/match/HalfTimeBreak.tsx
@@ -10,10 +10,10 @@ import {
   getTeamTalkOptions,
   TeamTalkTone,
 } from "./types";
-import { getEventDisplay, getPlayerName } from "./helpers";
+import { getEventDisplay, getPlayerName, makeTeamFallback } from "./helpers";
 import { getTalkIcon } from "./TeamTalkIcons";
 import { SubPanel } from "./SubPanel";
-import { Badge, ThemeToggle } from "../ui";
+import { Badge, TeamLogo, ThemeToggle } from "../ui";
 import {
   Play,
   RefreshCw,
@@ -68,12 +68,10 @@ export default function HalfTimeBreak({
     }[]
   >([]);
 
-  const homeTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.home_team.id)?.colors
-      ?.primary || "#10b981";
-  const awayTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.away_team.id)?.colors
-      ?.primary || "#6366f1";
+  const homeFullTeam = gameState.teams.find((t) => t.id === snapshot.home_team.id);
+  const awayFullTeam = gameState.teams.find((t) => t.id === snapshot.away_team.id);
+  const homeTeamColor = homeFullTeam?.colors?.primary || "#10b981";
+  const awayTeamColor = awayFullTeam?.colors?.primary || "#6366f1";
 
   const userTeam =
     userSide === "Home" ? snapshot.home_team : snapshot.away_team;
@@ -171,16 +169,16 @@ export default function HalfTimeBreak({
           <ThemeToggle className="absolute right-0 top-0" />
           <div className="flex items-center justify-center gap-8">
             <div className="flex items-center gap-3">
-              <div
-                className="w-12 h-12 rounded-xl flex items-center justify-center font-heading font-bold"
+              <TeamLogo
+                team={homeFullTeam ?? makeTeamFallback(snapshot.home_team.name)}
+                className="w-12 h-12 rounded-xl flex items-center justify-center font-heading font-bold overflow-hidden"
+                imageClassName="h-9 w-9 object-contain drop-shadow"
                 style={{
                   backgroundColor: homeTeamColor + "30",
                   borderColor: homeTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.home_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
               <p className="font-heading font-bold text-gray-800 dark:text-gray-200">
                 {snapshot.home_team.name}
               </p>
@@ -207,16 +205,16 @@ export default function HalfTimeBreak({
               <p className="font-heading font-bold text-gray-800 dark:text-gray-200">
                 {snapshot.away_team.name}
               </p>
-              <div
-                className="w-12 h-12 rounded-xl flex items-center justify-center font-heading font-bold"
+              <TeamLogo
+                team={awayFullTeam ?? makeTeamFallback(snapshot.away_team.name)}
+                className="w-12 h-12 rounded-xl flex items-center justify-center font-heading font-bold overflow-hidden"
+                imageClassName="h-9 w-9 object-contain drop-shadow"
                 style={{
                   backgroundColor: awayTeamColor + "30",
                   borderColor: awayTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.away_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
             </div>
           </div>
 

--- a/src/components/match/MatchLive.tsx
+++ b/src/components/match/MatchLive.tsx
@@ -3,8 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
 import { GameStateData } from "../../store/gameStore";
 import { MatchSnapshot, MatchEvent, MinuteResult, SimSpeed, SPEED_MS } from "./types";
-import { getEventDisplay, getPlayerName, phaseLabel } from "./helpers";
-import { Badge } from "../ui";
+import { getEventDisplay, getPlayerName, makeTeamFallback, phaseLabel } from "./helpers";
+import { Badge, TeamLogo } from "../ui";
 import { useSettingsStore } from "../../store/settingsStore";
 import { EventFeed, MatchStats, Lineups } from "./MatchPanels";
 import MatchScreenLayout from "./MatchScreenLayout";
@@ -47,8 +47,10 @@ export default function MatchLive({
   // Track phases we've already signaled to avoid double-firing
   const signaledRef = useRef<Set<string>>(new Set());
 
-  const homeTeamColor = gameState.teams.find(t => t.id === snapshot.home_team.id)?.colors?.primary || "#10b981";
-  const awayTeamColor = gameState.teams.find(t => t.id === snapshot.away_team.id)?.colors?.primary || "#6366f1";
+  const homeFullTeam = gameState.teams.find(t => t.id === snapshot.home_team.id);
+  const awayFullTeam = gameState.teams.find(t => t.id === snapshot.away_team.id);
+  const homeTeamColor = homeFullTeam?.colors?.primary || "#10b981";
+  const awayTeamColor = awayFullTeam?.colors?.primary || "#6366f1";
 
   const isFinished = snapshot.phase === "Finished";
 
@@ -199,12 +201,12 @@ export default function MatchLive({
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">{snapshot.home_team.formation}</p>
                 </div>
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm"
+                <TeamLogo
+                  team={homeFullTeam ?? makeTeamFallback(snapshot.home_team.name)}
+                  className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm overflow-hidden"
+                  imageClassName="h-8 w-8 object-contain drop-shadow"
                   style={{ backgroundColor: homeTeamColor + "30", borderColor: homeTeamColor, borderWidth: 2 }}
-                >
-                  {snapshot.home_team.name.substring(0, 3).toUpperCase()}
-                </div>
+                />
               </div>
 
               <div className="flex items-center gap-3">
@@ -219,12 +221,12 @@ export default function MatchLive({
               </div>
 
               <div className="flex items-center gap-3">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm"
+                <TeamLogo
+                  team={awayFullTeam ?? makeTeamFallback(snapshot.away_team.name)}
+                  className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm overflow-hidden"
+                  imageClassName="h-8 w-8 object-contain drop-shadow"
                   style={{ backgroundColor: awayTeamColor + "30", borderColor: awayTeamColor, borderWidth: 2 }}
-                >
-                  {snapshot.away_team.name.substring(0, 3).toUpperCase()}
-                </div>
+                />
                 <div className="text-left">
                   <p className="font-heading font-bold text-sm uppercase tracking-wider text-gray-800 dark:text-gray-200">
                     {snapshot.away_team.name}

--- a/src/components/match/PostMatchScreen.tsx
+++ b/src/components/match/PostMatchScreen.tsx
@@ -10,9 +10,9 @@ import {
   RoundSummary,
   TeamTalkTone,
 } from "./types";
-import { getEventDisplay, getPlayerName } from "./helpers";
+import { getEventDisplay, getPlayerName, makeTeamFallback } from "./helpers";
 import { getTalkIcon } from "./TeamTalkIcons";
-import { Badge, ThemeToggle } from "../ui";
+import { Badge, TeamLogo, ThemeToggle } from "../ui";
 import {
   QuickStat,
   renderScorers,
@@ -68,12 +68,10 @@ export default function PostMatchScreen({
     }[]
   >([]);
 
-  const homeTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.home_team.id)?.colors
-      ?.primary || "#10b981";
-  const awayTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.away_team.id)?.colors
-      ?.primary || "#6366f1";
+  const homeFullTeam = gameState.teams.find((t) => t.id === snapshot.home_team.id);
+  const awayFullTeam = gameState.teams.find((t) => t.id === snapshot.away_team.id);
+  const homeTeamColor = homeFullTeam?.colors?.primary || "#10b981";
+  const awayTeamColor = awayFullTeam?.colors?.primary || "#6366f1";
 
   const userScore =
     userSide === "Home" ? snapshot.home_score : snapshot.away_score;
@@ -335,16 +333,16 @@ export default function PostMatchScreen({
           {/* Scoreboard */}
           <div className="flex items-center justify-center gap-10">
             <div className="flex items-center gap-4">
-              <div
-                className="w-16 h-16 rounded-xl flex items-center justify-center font-heading font-bold text-lg"
+              <TeamLogo
+                team={homeFullTeam ?? makeTeamFallback(snapshot.home_team.name)}
+                className="w-16 h-16 rounded-xl flex items-center justify-center font-heading font-bold text-lg overflow-hidden"
+                imageClassName="h-12 w-12 object-contain drop-shadow"
                 style={{
                   backgroundColor: homeTeamColor + "30",
                   borderColor: homeTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.home_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
               <p className="font-heading font-bold text-lg text-gray-800 dark:text-gray-200">
                 {snapshot.home_team.name}
               </p>
@@ -371,16 +369,16 @@ export default function PostMatchScreen({
               <p className="font-heading font-bold text-lg text-gray-800 dark:text-gray-200">
                 {snapshot.away_team.name}
               </p>
-              <div
-                className="w-16 h-16 rounded-xl flex items-center justify-center font-heading font-bold text-lg"
+              <TeamLogo
+                team={awayFullTeam ?? makeTeamFallback(snapshot.away_team.name)}
+                className="w-16 h-16 rounded-xl flex items-center justify-center font-heading font-bold text-lg overflow-hidden"
+                imageClassName="h-12 w-12 object-contain drop-shadow"
                 style={{
                   backgroundColor: awayTeamColor + "30",
                   borderColor: awayTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.away_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
             </div>
           </div>
         </div>

--- a/src/components/match/PreMatchLineup.tsx
+++ b/src/components/match/PreMatchLineup.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from "react-i18next";
 import { MatchSnapshot, EnginePlayerData } from "./types";
-import { Badge } from "../ui";
+import { makeTeamFallback } from "./helpers";
+import { Badge, TeamLogo } from "../ui";
+import type { TeamData } from "../../store/gameStore";
 import { ArrowUpDown, AlertTriangle, Wand2 } from "lucide-react";
 import ContextMenu from "../ContextMenu";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
@@ -143,6 +145,7 @@ interface PreMatchLineupProps {
   userTeam: MatchSnapshot["home_team"];
   userBench: EnginePlayerData[];
   oppTeam: MatchSnapshot["home_team"];
+  oppFullTeam?: TeamData;
   userColor: string;
   homeTeamColor: string;
   awayTeamColor: string;
@@ -159,6 +162,7 @@ export default function PreMatchLineup({
   userTeam,
   userBench,
   oppTeam,
+  oppFullTeam,
   userColor,
   homeTeamColor,
   awayTeamColor,
@@ -458,16 +462,16 @@ export default function PreMatchLineup({
               {t("match.opponent")}
             </h3>
             <div className="flex items-center gap-3 mb-2">
-              <div
-                className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm"
+              <TeamLogo
+                team={oppFullTeam ?? makeTeamFallback(oppTeam.name)}
+                className="w-10 h-10 rounded-lg flex items-center justify-center font-heading font-bold text-sm overflow-hidden"
+                imageClassName="h-8 w-8 object-contain drop-shadow"
                 style={{
                   backgroundColor:
                     (userSide === "Home" ? awayTeamColor : homeTeamColor) +
                     "30",
                 }}
-              >
-                {oppTeam.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
               <div>
                 <p className="font-heading font-bold text-sm text-gray-800 dark:text-gray-200">
                   {oppTeam.name}

--- a/src/components/match/PreMatchSetup.tsx
+++ b/src/components/match/PreMatchSetup.tsx
@@ -9,6 +9,8 @@ import PreMatchLineup, {
 } from "./PreMatchLineup";
 import MatchScreenLayout from "./MatchScreenLayout";
 import SetPieceSelector from "./SetPieceSelector";
+import { makeTeamFallback } from "./helpers";
+import { TeamLogo } from "../ui";
 import {
   ChevronRight,
   Shield,
@@ -63,12 +65,10 @@ export default function PreMatchSetup({
   const userSetPieces =
     userSide === "Home" ? snapshot.home_set_pieces : snapshot.away_set_pieces;
 
-  const homeTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.home_team.id)?.colors
-      ?.primary || "#10b981";
-  const awayTeamColor =
-    gameState.teams.find((t) => t.id === snapshot.away_team.id)?.colors
-      ?.primary || "#6366f1";
+  const homeFullTeam = gameState.teams.find((t) => t.id === snapshot.home_team.id);
+  const awayFullTeam = gameState.teams.find((t) => t.id === snapshot.away_team.id);
+  const homeTeamColor = homeFullTeam?.colors?.primary || "#10b981";
+  const awayTeamColor = awayFullTeam?.colors?.primary || "#6366f1";
   const userColor = userSide === "Home" ? homeTeamColor : awayTeamColor;
   const fixtureLabel = currentFixture
     ? getFixtureDisplayLabel(t, currentFixture)
@@ -226,16 +226,16 @@ export default function PreMatchSetup({
         <>
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-4">
-              <div
-                className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-lg"
+              <TeamLogo
+                team={homeFullTeam ?? makeTeamFallback(snapshot.home_team.name)}
+                className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-lg overflow-hidden"
+                imageClassName="h-11 w-11 object-contain drop-shadow"
                 style={{
                   backgroundColor: homeTeamColor + "30",
                   borderColor: homeTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.home_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
               <div>
                 <p className="font-heading font-bold text-lg text-gray-900 dark:text-white">
                   {snapshot.home_team.name}
@@ -266,16 +266,16 @@ export default function PreMatchSetup({
                   {t(`common.playStyles.${snapshot.away_team.play_style}`, snapshot.away_team.play_style)}
                 </p>
               </div>
-              <div
-                className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-lg"
+              <TeamLogo
+                team={awayFullTeam ?? makeTeamFallback(snapshot.away_team.name)}
+                className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-lg overflow-hidden"
+                imageClassName="h-11 w-11 object-contain drop-shadow"
                 style={{
                   backgroundColor: awayTeamColor + "30",
                   borderColor: awayTeamColor,
                   borderWidth: 2,
                 }}
-              >
-                {snapshot.away_team.name.substring(0, 3).toUpperCase()}
-              </div>
+              />
             </div>
           </div>
 
@@ -366,6 +366,7 @@ export default function PreMatchSetup({
             userTeam={userTeam}
             userBench={userBench}
             oppTeam={oppTeam}
+            oppFullTeam={userSide === "Home" ? awayFullTeam : homeFullTeam}
             userColor={userColor}
             homeTeamColor={homeTeamColor}
             awayTeamColor={awayTeamColor}

--- a/src/components/match/helpers.test.ts
+++ b/src/components/match/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   phaseLabel,
   getEventDisplay,
   getEventTypeLabel,
+  makeTeamFallback,
   resolveMatchFixture,
 } from "./helpers";
 import i18n, { i18nReady } from "../../i18n";
@@ -113,6 +114,22 @@ describe("getPlayerName", () => {
 
   it("returns the id when player not found", () => {
     expect(getPlayerName(snapshot, "unknown_id")).toBe("unknown_id");
+  });
+});
+
+describe("makeTeamFallback", () => {
+  it("builds a short-name fallback for teams without full team data", () => {
+    expect(makeTeamFallback("Sporting Club")).toEqual({
+      name: "Sporting Club",
+      short_name: "SPO",
+    });
+  });
+
+  it("pads very short team names to three characters", () => {
+    expect(makeTeamFallback("FC")).toEqual({
+      name: "FC",
+      short_name: "FC ",
+    });
   });
 });
 

--- a/src/components/match/helpers.tsx
+++ b/src/components/match/helpers.tsx
@@ -147,6 +147,13 @@ function humanizeEventType(eventType: string): string {
 
 type TranslateFn = (key: string, options?: { defaultValue?: string }) => string;
 
+export function makeTeamFallback(teamName: string) {
+  return {
+    name: teamName,
+    short_name: teamName.substring(0, 3).toUpperCase().padEnd(3, " "),
+  };
+}
+
 export function getEventDisplay(evt: MatchEvent) {
   return EVENT_ICONS[evt.event_type] || DEFAULT_DISPLAY;
 }

--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -947,14 +947,16 @@ describe("PlayerProfile contract surfaces", () => {
     });
   });
 
-  it("disables renewal delegation when no assistant manager is assigned", () => {
+  it("disables renewal delegation when no assistant manager is assigned", async () => {
     render(<RenewalHarness />);
 
     fireEvent.click(screen.getByRole("button", { name: "Renew Contract" }));
 
-    expect(
-      screen.getByRole("button", { name: "Delegate to Assistant" }),
-    ).toBeDisabled();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Delegate to Assistant" }),
+      ).toBeDisabled();
+    });
   });
 
   it("localizes the no-assistant delegation error if the command still fails", async () => {

--- a/src/components/playerProfile/PlayerProfileHeroCard.tsx
+++ b/src/components/playerProfile/PlayerProfileHeroCard.tsx
@@ -12,7 +12,7 @@ import type {
 } from "./PlayerProfile.scouting";
 import PlayerProfileScoutAction from "./PlayerProfileScoutAction";
 import { TraitList } from "../TraitBadge";
-import { Badge, Card, CountryFlag } from "../ui";
+import { Badge, Card, CountryFlag, PlayerAvatar } from "../ui";
 
 type TranslateFn = (
     key: string,
@@ -64,16 +64,16 @@ export default function PlayerProfileHeroCard({
         <Card accent="primary" className="mb-5">
             <div className="bg-linear-to-r from-navy-700 to-navy-800 p-8 rounded-t-xl">
                 <div className="flex items-start gap-6">
-                    <div
-                        className={`w-24 h-24 rounded-2xl flex items-center justify-center font-heading font-bold text-4xl border-2 ${ovr >= 75
+                    <PlayerAvatar
+                        player={player}
+                        className={`w-24 h-24 rounded-2xl flex items-center justify-center font-heading font-bold text-4xl border-2 overflow-hidden ${ovr >= 75
                             ? "bg-primary-500/20 text-primary-400 border-primary-500/30"
                             : ovr >= 55
                                 ? "bg-accent-500/20 text-accent-400 border-accent-500/30"
                                 : "bg-gray-500/20 text-gray-400 border-gray-500/30"
                             }`}
-                    >
-                        {ovr}
-                    </div>
+                        fallback={<span>{ovr}</span>}
+                    />
                     <div className="flex-1">
                         <h2 className="text-3xl font-heading font-bold text-white uppercase tracking-wide">
                             {player.full_name}

--- a/src/components/players/PlayersListTab.tsx
+++ b/src/components/players/PlayersListTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { GameStateData, PlayerSelectionOptions } from "../../store/gameStore";
 import { getErrorMessage, resolveTranslatedErrorMessage } from "../../utils/errorMessage";
-import { Card, CardBody, Badge, Select, CountryFlag } from "../ui";
+import { Card, CardBody, Badge, Select, CountryFlag, PlayerAvatar } from "../ui";
 import ContextMenu from "../ContextMenu";
 import {
   Search,
@@ -463,9 +463,12 @@ export default function PlayersListTab({
                           </Badge>
                         </td>
                         <td className="py-2.5 px-4">
-                          <span className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-                            {player.full_name}
-                          </span>
+                          <div className="flex items-center gap-3">
+                            <PlayerAvatar player={player} />
+                            <span className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                              {player.full_name}
+                            </span>
+                          </div>
                         </td>
                         <td className="py-2.5 px-4 text-sm text-gray-600 dark:text-gray-400 tabular-nums">
                           {age}

--- a/src/components/scouting/ScoutingPlayerSearchCard.tsx
+++ b/src/components/scouting/ScoutingPlayerSearchCard.tsx
@@ -13,7 +13,7 @@ import {
   buildViewProfileMenuItem,
   buildViewTeamMenuItem,
 } from "../playerActions/playerContextMenuItems";
-import { Badge, Card, CardBody, CardHeader, CountryFlag } from "../ui";
+import { Badge, Card, CardBody, CardHeader, CountryFlag, PlayerAvatar } from "../ui";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
 
 const POSITION_FILTERS = [
@@ -182,19 +182,24 @@ export default function ScoutingPlayerSearchCard({
                     className="border-b border-gray-50 dark:border-navy-700/50 hover:bg-gray-50 dark:hover:bg-navy-700/30 transition-colors"
                   >
                     <td className="py-2 px-2">
-                      <button
-                        onClick={() => onSelectPlayer?.(player.id)}
-                        className="font-heading font-bold text-gray-800 dark:text-gray-100 hover:text-primary-500 transition-colors text-left"
-                      >
-                        {player.full_name}
-                      </button>
-                      <div className="text-[10px] text-gray-400 mt-0.5 flex items-center gap-1">
-                        <CountryFlag
-                          code={player.nationality}
-                          locale={i18n.language}
-                          className="text-xs leading-none"
-                        />
-                        <span>{countryName(player.nationality, i18n.language)}</span>
+                      <div className="flex items-center gap-2">
+                        <PlayerAvatar player={player} className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-[10px] font-heading font-bold text-gray-500 dark:text-gray-300" />
+                        <div className="min-w-0">
+                          <button
+                            onClick={() => onSelectPlayer?.(player.id)}
+                            className="font-heading font-bold text-gray-800 dark:text-gray-100 hover:text-primary-500 transition-colors text-left"
+                          >
+                            {player.full_name}
+                          </button>
+                          <div className="text-[10px] text-gray-400 mt-0.5 flex items-center gap-1">
+                            <CountryFlag
+                              code={player.nationality}
+                              locale={i18n.language}
+                              className="text-xs leading-none"
+                            />
+                            <span>{countryName(player.nationality, i18n.language)}</span>
+                          </div>
+                        </div>
                       </div>
                     </td>
                     <td className="py-2 px-1">

--- a/src/components/squad/SquadRosterView.tsx
+++ b/src/components/squad/SquadRosterView.tsx
@@ -4,7 +4,7 @@ import type {
   PlayerData,
   PlayerSelectionOptions,
 } from "../../store/gameStore";
-import { Badge, Button, Card, ProgressBar, Select, CountryFlag } from "../ui";
+import { Badge, Button, Card, ProgressBar, Select, CountryFlag, PlayerAvatar } from "../ui";
 import {
   AlertTriangle,
   ChevronDown,
@@ -565,10 +565,15 @@ export default function SquadRosterView({
                         </div>
                       </td>
                       <td className="py-2.5 px-4">
-                        <div className="font-semibold text-sm text-gray-900 dark:text-gray-100 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-                          {player.full_name}
+                        <div className="flex items-center gap-3">
+                          <PlayerAvatar player={player} />
+                          <div>
+                            <div className="font-semibold text-sm text-gray-900 dark:text-gray-100 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                              {player.full_name}
+                            </div>
+                            {renderPreferredPositionMeta(player)}
+                          </div>
                         </div>
-                        {renderPreferredPositionMeta(player)}
                       </td>
                       <td className="py-2.5 px-4 text-sm text-gray-600 dark:text-gray-400 tabular-nums">
                         {age}

--- a/src/components/teamProfile/TeamProfileHeroCard.tsx
+++ b/src/components/teamProfile/TeamProfileHeroCard.tsx
@@ -1,6 +1,6 @@
 import { Calendar, Users } from "lucide-react";
 
-import { Card, TeamLocation } from "../ui";
+import { Card, TeamLocation, TeamLogo } from "../ui";
 import type { TeamProfileTranslate } from "./TeamProfile.types";
 import { QuickStat } from "./TeamProfile.primitives";
 import type { TeamProfileViewModel } from "./TeamProfile.types";
@@ -28,12 +28,12 @@ export default function TeamProfileHeroCard({
         }}
       >
         <div className="flex items-start gap-6">
-          <div
-            className="w-24 h-24 rounded-2xl flex items-center justify-center font-heading font-bold text-3xl text-white border-2 border-white/30"
+          <TeamLogo
+            team={team}
+            className="w-24 h-24 rounded-2xl flex items-center justify-center font-heading font-bold text-3xl text-white border-2 border-white/30 overflow-hidden"
+            imageClassName="h-20 w-20 object-contain drop-shadow"
             style={{ backgroundColor: team.colors.primary }}
-          >
-            {team.short_name}
-          </div>
+          />
           <div className="flex-1">
             <h2 className="text-3xl font-heading font-bold text-white uppercase tracking-wide drop-shadow">
               {team.name}

--- a/src/components/teamProfile/TeamProfileRosterCard.tsx
+++ b/src/components/teamProfile/TeamProfileRosterCard.tsx
@@ -8,7 +8,7 @@ import {
 import type { PlayerData } from "../../store/gameStore";
 import ContextMenu from "../ContextMenu";
 import { buildViewProfileMenuItem } from "../playerActions/playerContextMenuItems";
-import { Badge, Card, CardBody, CardHeader, CountryFlag, ProgressBar } from "../ui";
+import { Badge, Card, CardBody, CardHeader, CountryFlag, PlayerAvatar, ProgressBar } from "../ui";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
 import type { TeamProfileTranslate } from "./TeamProfile.types";
 
@@ -92,9 +92,12 @@ export default function TeamProfileRosterCard({
                       </Badge>
                     </td>
                     <td className="py-3 px-5">
-                      <span className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-                        {player.full_name}
-                      </span>
+                      <div className="flex items-center gap-3 min-w-0">
+                        <PlayerAvatar player={player} />
+                        <span className="block truncate font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                          {player.full_name}
+                        </span>
+                      </div>
                     </td>
                     <td className="py-3 px-5 text-sm text-gray-600 dark:text-gray-400 tabular-nums">
                       {age}

--- a/src/components/teams/TeamsListTab.tsx
+++ b/src/components/teams/TeamsListTab.tsx
@@ -1,5 +1,5 @@
 import { GameStateData } from "../../store/gameStore";
-import { Card, CardBody, Badge, TeamLocation } from "../ui";
+import { Card, CardBody, Badge, TeamLocation, TeamLogo } from "../ui";
 import { Users, Trophy } from "lucide-react";
 import { formatVal, getPlayerOvr } from "../../lib/helpers";
 import { useTranslation } from "react-i18next";
@@ -51,12 +51,12 @@ export default function TeamsListTab({ gameState, onSelectTeam }: TeamsListTabPr
                   className="p-5 flex items-center gap-4"
                   style={{ background: `linear-gradient(135deg, ${team.colors.primary}, ${team.colors.secondary}40)` }}
                 >
-                  <div
-                    className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-xl text-white border-2 border-white/30"
+                  <TeamLogo
+                    team={team}
+                    className="w-14 h-14 rounded-xl flex items-center justify-center font-heading font-bold text-xl text-white border-2 border-white/30 bg-white/15 overflow-hidden"
+                    imageClassName="h-12 w-12 object-contain drop-shadow"
                     style={{ backgroundColor: team.colors.primary }}
-                  >
-                    {team.short_name}
-                  </div>
+                  />
                   <div className="flex-1 min-w-0">
                     <h3 className="font-heading font-bold text-lg text-white uppercase tracking-wide truncate drop-shadow">
                       {team.name}

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -5,7 +5,7 @@ import {
   PlayerSelectionOptions,
   TransferOfferData,
 } from "../../store/gameStore";
-import { Card, CardBody, Badge, CountryFlag } from "../ui";
+import { Card, CardBody, Badge, CountryFlag, PlayerAvatar } from "../ui";
 import ContextMenu from "../ContextMenu";
 import {
   Search,
@@ -630,18 +630,23 @@ export default function TransfersTab({
                           </Badge>
                         </td>
                         <td className="py-2.5 px-4">
-                          <span className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-                            {player.full_name}
-                          </span>
-                          <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 flex items-center gap-1">
-                            <CountryFlag
-                              code={player.nationality}
-                              locale={i18n.language}
-                              className="text-sm leading-none"
-                            />
-                            <span>
-                              {countryName(player.nationality, i18n.language)}
-                            </span>
+                          <div className="flex items-center gap-3">
+                            <PlayerAvatar player={player} />
+                            <div className="min-w-0">
+                              <span className="block truncate font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                                {player.full_name}
+                              </span>
+                              <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 flex items-center gap-1">
+                                <CountryFlag
+                                  code={player.nationality}
+                                  locale={i18n.language}
+                                  className="text-sm leading-none"
+                                />
+                                <span>
+                                  {countryName(player.nationality, i18n.language)}
+                                </span>
+                              </div>
+                            </div>
                           </div>
                         </td>
                         <td className="py-2.5 px-4 text-sm text-gray-600 dark:text-gray-400 tabular-nums">

--- a/src/components/ui/AssetImage.tsx
+++ b/src/components/ui/AssetImage.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+interface AssetImageProps {
+  src: string | null;
+  alt: string;
+  className?: string;
+  fallback: ReactNode;
+}
+
+export default function AssetImage({
+  src,
+  alt,
+  className = "",
+  fallback,
+}: AssetImageProps) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  if (!src || failed) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      loading="lazy"
+      referrerPolicy="no-referrer"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/components/ui/PlayerAvatar.test.tsx
+++ b/src/components/ui/PlayerAvatar.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlayerAvatar } from "./PlayerAvatar";
+
+const player = {
+  full_name: "John Smith",
+  match_name: "J. Smith",
+};
+
+describe("PlayerAvatar", () => {
+  it("renders player initials when no face media path is provided", () => {
+    render(<PlayerAvatar player={player} />);
+
+    expect(screen.getByText("J.")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders a local face image when face media path is provided", () => {
+    render(
+      <PlayerAvatar
+        player={{
+          ...player,
+          media: { face: "assets/worlds/test-world/players/player-1.png" },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "John Smith" })).toHaveAttribute(
+      "src",
+      "/assets/worlds/test-world/players/player-1.png",
+    );
+  });
+
+  it("falls back to initials when the face image fails to load", () => {
+    render(
+      <PlayerAvatar
+        player={{
+          ...player,
+          media: { face: "/assets/worlds/test-world/players/player-1.png" },
+        }}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "John Smith" }));
+
+    expect(screen.getByText("J.")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/PlayerAvatar.tsx
+++ b/src/components/ui/PlayerAvatar.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { resolveLocalMediaPath } from "../../lib/mediaAssets";
+import AssetImage from "./AssetImage";
+
+interface PlayerAvatarPlayer {
+  full_name: string;
+  match_name: string;
+  media?: {
+    face?: string;
+  };
+}
+
+interface PlayerAvatarProps {
+  player: PlayerAvatarPlayer;
+  className?: string;
+  imageClassName?: string;
+  fallback?: ReactNode;
+}
+
+function playerInitials(player: PlayerAvatarPlayer): string {
+  const source = player.match_name || player.full_name;
+  return source.slice(0, 2).toUpperCase();
+}
+
+export function PlayerAvatar({
+  player,
+  className = "h-9 w-9 shrink-0 overflow-hidden rounded-lg bg-gray-100 dark:bg-navy-700 flex items-center justify-center text-xs font-heading font-bold text-gray-500 dark:text-gray-300",
+  imageClassName = "h-full w-full object-cover",
+  fallback,
+}: PlayerAvatarProps) {
+  return (
+    <div className={className}>
+      <AssetImage
+        src={resolveLocalMediaPath(player.media?.face)}
+        alt={player.full_name}
+        className={imageClassName}
+        fallback={fallback ?? <span>{playerInitials(player)}</span>}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/TeamLogo.test.tsx
+++ b/src/components/ui/TeamLogo.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TeamLogo } from "./TeamLogo";
+
+const team = {
+  name: "Media FC",
+  short_name: "MFC",
+};
+
+describe("TeamLogo", () => {
+  it("renders the team short name when no logo media path is provided", () => {
+    render(<TeamLogo team={team} />);
+
+    expect(screen.getByText("MFC")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders a local logo image when logo media path is provided", () => {
+    render(
+      <TeamLogo
+        team={{
+          ...team,
+          media: { logo: "assets/worlds/test-world/teams/media-fc.png" },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Media FC logo" })).toHaveAttribute(
+      "src",
+      "/assets/worlds/test-world/teams/media-fc.png",
+    );
+  });
+
+  it("falls back to the team short name when the logo image fails to load", () => {
+    render(
+      <TeamLogo
+        team={{
+          ...team,
+          media: { logo: "/assets/worlds/test-world/teams/media-fc.png" },
+        }}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Media FC logo" }));
+
+    expect(screen.getByText("MFC")).toBeInTheDocument();
+  });
+
+  it("tries to render a new logo path after a previous image failed", () => {
+    const { rerender } = render(
+      <TeamLogo
+        team={{
+          ...team,
+          media: { logo: "/assets/worlds/test-world/teams/missing.png" },
+        }}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Media FC logo" }));
+    expect(screen.getByText("MFC")).toBeInTheDocument();
+
+    rerender(
+      <TeamLogo
+        team={{
+          ...team,
+          media: { logo: "/assets/worlds/test-world/teams/media-fc.png" },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Media FC logo" })).toHaveAttribute(
+      "src",
+      "/assets/worlds/test-world/teams/media-fc.png",
+    );
+  });
+});

--- a/src/components/ui/TeamLogo.tsx
+++ b/src/components/ui/TeamLogo.tsx
@@ -1,0 +1,38 @@
+import type { CSSProperties, ReactNode } from "react";
+import { resolveLocalMediaPath } from "../../lib/mediaAssets";
+import AssetImage from "./AssetImage";
+
+interface TeamLogoTeam {
+  name: string;
+  short_name: string;
+  media?: {
+    logo?: string;
+  };
+}
+
+interface TeamLogoProps {
+  team: TeamLogoTeam;
+  className?: string;
+  imageClassName?: string;
+  fallback?: ReactNode;
+  style?: CSSProperties;
+}
+
+export function TeamLogo({
+  team,
+  className = "h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-white/10 flex items-center justify-center font-heading font-bold text-lg text-white",
+  imageClassName = "h-10 w-10 object-contain drop-shadow",
+  fallback,
+  style,
+}: TeamLogoProps) {
+  return (
+    <div className={className} style={style}>
+      <AssetImage
+        src={resolveLocalMediaPath(team.media?.logo)}
+        alt={`${team.name} logo`}
+        className={imageClassName}
+        fallback={fallback ?? <span>{team.short_name}</span>}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,3 +7,5 @@ export { TeamLocation } from "./TeamLocation";
 export { ThemeToggle } from "./ThemeToggle";
 export { DatePicker } from "./DatePicker";
 export { Select } from "./Select";
+export { PlayerAvatar } from "./PlayerAvatar";
+export { TeamLogo } from "./TeamLogo";

--- a/src/components/youthAcademy/YouthAcademyTab.tsx
+++ b/src/components/youthAcademy/YouthAcademyTab.tsx
@@ -8,6 +8,7 @@ import {
   ProgressBar,
   CountryFlag,
   Button,
+  PlayerAvatar,
 } from "../ui";
 import { calcAge, positionBadgeVariant } from "../../lib/helpers";
 import { canDelegateToYouthAcademy, isYouthAcademyPlayer } from "../../lib/playerSquad";
@@ -292,19 +293,22 @@ export default function YouthAcademyTab({
                     key={player.id}
                     className="flex items-center justify-between gap-3 rounded-xl border border-gray-200 dark:border-navy-600 bg-gray-50 dark:bg-navy-800/60 px-4 py-3"
                   >
-                    <div className="min-w-0">
-                      <button
-                        onClick={() => onSelectPlayer?.(player.id)}
-                        className="text-left font-heading font-bold text-sm text-gray-800 dark:text-gray-100 hover:text-primary-500 transition-colors truncate block"
-                      >
-                        {player.full_name}
-                      </button>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                        {translatePositionAbbreviation(
-                          t,
-                          player.natural_position || player.position,
-                        )} · {t("youthAcademy.age")} {player.age}
-                      </p>
+                    <div className="min-w-0 flex items-center gap-3">
+                      <PlayerAvatar player={player} />
+                      <div className="min-w-0">
+                        <button
+                          onClick={() => onSelectPlayer?.(player.id)}
+                          className="text-left font-heading font-bold text-sm text-gray-800 dark:text-gray-100 hover:text-primary-500 transition-colors truncate block"
+                        >
+                          {player.full_name}
+                        </button>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          {translatePositionAbbreviation(
+                            t,
+                            player.natural_position || player.position,
+                          )} · {t("youthAcademy.age")} {player.age}
+                        </p>
+                      </div>
                     </div>
 
                     <Button
@@ -439,19 +443,22 @@ export default function YouthAcademyTab({
                         className="hover:bg-gray-50 dark:hover:bg-navy-700/50 cursor-pointer transition-colors"
                       >
                         <td className="py-2.5 px-4">
-                          <div>
-                            <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
-                              {player.full_name}
-                            </p>
-                            <div className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1 mt-0.5">
-                              <CountryFlag
-                                code={player.nationality}
-                                locale={i18n.language}
-                                className="text-xs leading-none"
-                              />
-                              <span>
-                                {countryName(player.nationality, i18n.language)}
-                              </span>
+                          <div className="flex items-center gap-3 min-w-0">
+                            <PlayerAvatar player={player} />
+                            <div className="min-w-0">
+                              <p className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
+                                {player.full_name}
+                              </p>
+                              <div className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1 mt-0.5">
+                                <CountryFlag
+                                  code={player.nationality}
+                                  locale={i18n.language}
+                                  className="text-xs leading-none"
+                                />
+                                <span>
+                                  {countryName(player.nationality, i18n.language)}
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/src/lib/mediaAssets.test.ts
+++ b/src/lib/mediaAssets.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocalMediaPath } from "./mediaAssets";
+
+describe("resolveLocalMediaPath", () => {
+  it("normalizes relative local media paths", () => {
+    expect(resolveLocalMediaPath("assets/worlds/demo/logo.png")).toBe(
+      "/assets/worlds/demo/logo.png",
+    );
+  });
+
+  it("keeps absolute local media paths", () => {
+    expect(resolveLocalMediaPath("/assets/worlds/demo/logo.png")).toBe(
+      "/assets/worlds/demo/logo.png",
+    );
+  });
+
+  it("rejects URI schemes and protocol-relative URLs", () => {
+    expect(resolveLocalMediaPath("https://example.com/logo.png")).toBeNull();
+    expect(resolveLocalMediaPath("DATA:image/png;base64,abc")).toBeNull();
+    expect(resolveLocalMediaPath("javascript:alert(1)")).toBeNull();
+    expect(resolveLocalMediaPath("//example.com/logo.png")).toBeNull();
+  });
+});

--- a/src/lib/mediaAssets.ts
+++ b/src/lib/mediaAssets.ts
@@ -1,0 +1,10 @@
+const URI_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+export function resolveLocalMediaPath(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const trimmed = path.trim();
+  if (!trimmed || URI_SCHEME.test(trimmed) || trimmed.startsWith("//")) {
+    return null;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}

--- a/src/pages/TeamSelection.tsx
+++ b/src/pages/TeamSelection.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useGameStore, GameStateData, PlayerData } from "../store/gameStore";
 import { formatVal, getPlayerOvr } from "../lib/helpers";
-import { Card, CardBody, Badge, TeamLocation, ThemeToggle } from "../components/ui";
+import { Card, CardBody, Badge, TeamLocation, ThemeToggle, TeamLogo } from "../components/ui";
 import { ArrowLeft, Users, Trophy, Landmark, ChevronRight, Star, Loader2 } from "lucide-react";
 import { resolveBackendError } from "../utils/backendI18n";
 
@@ -125,12 +125,13 @@ export default function TeamSelection() {
                     }`}>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <div className={`w-12 h-12 rounded-lg flex items-center justify-center font-heading font-bold text-lg ${isSelected
-                          ? "bg-white/20 text-white"
-                          : "bg-white/10 text-gray-300"
-                          }`}>
-                          {team.short_name}
-                        </div>
+                        <TeamLogo
+                          team={team}
+                          className={`w-12 h-12 rounded-lg flex items-center justify-center font-heading font-bold text-lg overflow-hidden ${isSelected
+                            ? "bg-white/20 text-white"
+                            : "bg-white/10 text-gray-300"
+                            }`}
+                        />
                         <div>
                           <h3 className="font-heading font-bold text-white uppercase tracking-wide text-sm">
                             {team.name}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -48,6 +48,12 @@ export interface TeamMatchRolesData {
   corner_taker: string | null;
 }
 
+/** Optional media paths for team branding. resolveLocalMediaPath accepts local paths only. */
+export interface TeamMediaData {
+  /** Local path to a team logo image; remote URLs and data URIs are ignored. */
+  logo?: string;
+}
+
 export interface TeamData {
   id: string;
   name: string;
@@ -71,6 +77,7 @@ export interface TeamData {
   training_schedule: string;
   founded_year: number;
   colors: TeamColors;
+  media?: TeamMediaData;
   facilities?: FacilitiesData;
   sponsorship?: SponsorshipData | null;
   starting_xi_ids: string[];
@@ -129,6 +136,12 @@ export interface PlayerMoraleCoreData {
 
 export type PlayerSquadRole = "Senior" | "Youth";
 
+/** Optional media paths for player visuals. resolveLocalMediaPath accepts local paths only. */
+export interface PlayerMediaData {
+  /** Local path to a player face image; remote URLs and data URIs are ignored. */
+  face?: string;
+}
+
 export interface PlayerData {
   id: string;
   match_name: string;
@@ -136,6 +149,7 @@ export interface PlayerData {
   date_of_birth: string;
   nationality: string;
   football_nation?: string;
+  media?: PlayerMediaData;
   position: string;
   natural_position: string;
   alternate_positions: string[];


### PR DESCRIPTION
## Summary

Adds optional generic media-path support for custom world databases.

World authors can now provide local asset paths for:

- `Team.media.logo`
- `Player.media.face`

The app persists those fields in saves and renders them through reusable UI components with fallback text/initials when media is missing or fails to load.

This is provider-agnostic and does not include any third-party logos, player faces, real-world database exports, or provider-specific URL logic.

## Context

This helps move forward the roadmap items in #11 for supporting club logo images and player profile pictures.

## Changes

- Adds `media` fields to team/player domain models.
- Persists media as `media_json` on teams and players.
- Adds a migration for existing saves.
- Adds a generic local media resolution helper.
- Adds reusable UI components:
  - `AssetImage`
  - `TeamLogo`
  - `PlayerAvatar`
- Updates team/player identity UI across lists, profiles, search results, home widgets, match screens, transfers, scouting, youth academy, team selection,
and hall of fame champions.
- Documents optional media fields in world database JSON.
- Adds tests for frontend media fallback/render behavior and DB media round-tripping.

## Usage example

```txt
src-tauri/databases/my-world.json
public/assets/worlds/my-world/teams/1001.svg
public/assets/worlds/my-world/players/50001.webp
```

```json
{
  "teams": [
    {
      "id": "1001",
      "name": "Northbridge FC",
      "short_name": "NOR",
      "media": {
        "logo": "assets/worlds/my-world/teams/1001.svg"
      }
    }
  ],
  "players": [
    {
      "id": "50001",
      "team_id": "1001",
      "match_name": "A. Rivera",
      "full_name": "Alex Rivera",
      "media": {
        "face": "assets/worlds/my-world/players/50001.webp"
      }
    }
  ]
}
```

Using stable numeric-string IDs for filenames helps avoid name collisions. Remote URLs and `data:` URLs are intentionally ignored; this only supports local media paths.

## Notes

- Media paths are local-only; remote/data URLs are ignored.
- Existing worlds and saves continue to work through fallback UI.

## Verification

- `npm test`
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team logos and player avatars added across the app; new image component and local-media path resolver with graceful fallbacks.

* **Documentation**
  * README updated with guidance and JSON examples for local world media assets.

* **Tests**
  * New/updated tests for avatars, logos, image handling, and media-path normalization; DB media round-trip tests added.

* **Chores**
  * Database schema updated to persist team/player media; ignore rules updated for local asset files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

