### PR TITLE
Epic: World Staff Replenish + Adaptive AI Training  #206

### DIFF
--- a/src-tauri/crates/ofm_core/src/ai_training.rs
+++ b/src-tauri/crates/ofm_core/src/ai_training.rs
@@ -41,7 +41,9 @@ const CONGESTION_FIXTURE_THRESHOLD: usize = 2;
 /// Returns a 5-slot weekly focus cycle for the given play style.
 ///
 /// Indexed by `weekday_num % 5`:
-///   0 = Mon slot, 1 = Tue slot, 2 = Wed slot, 3 = Thu slot, 4 = Fri/Sat slot.
+///   0 = Mon slot, 1 = Tue slot, 2 = Wed slot, 3 = Thu slot, 4 = Fri slot.
+///   With modulo-5 indexing, Saturday (`weekday_num = 5`) wraps to slot 0
+///   (the Monday slot), so the 5-slot cycle repeats Monday-Friday.
 ///
 /// Balanced uses one of each focus.
 /// Every other style has 3 slots for its biased focus (2 extras vs the base).

--- a/src-tauri/crates/ofm_core/src/ai_training.rs
+++ b/src-tauri/crates/ofm_core/src/ai_training.rs
@@ -1,0 +1,597 @@
+//! AI-only daily training policy.
+//!
+//! Applies automated training focus and intensity decisions to all non-user teams
+//! each non-match training day, BEFORE `training::process_training` runs.
+//!
+//! Algorithm:
+//! 1. Skip the user-controlled team entirely.
+//! 2. Skip if today is a rest day for that team's schedule.
+//! 3. If avg available-player condition < 10 → Recovery focus + Low intensity (no cycle advance).
+//! 4. Otherwise compute intensity from condition band (Low/Medium/High).
+//! 5. Apply near-match / congestion downgrade where applicable.
+//! 6. Pick focus from the style-biased 5-slot weekly cycle (indexed by weekday % 5).
+//! 7. Force Recovery focus when final intensity is Low (fatigue band or downgraded).
+//! 8. Force Tactical focus when congested but intensity is still Medium.
+//! 9. V1 safety rule: Physical + High → downgrade intensity to Medium.
+
+use crate::game::Game;
+use chrono::NaiveDate;
+use domain::league::FixtureStatus;
+use domain::team::{PlayStyle, TrainingFocus, TrainingIntensity};
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+/// Below this avg condition: full recovery day (no cycle advance).
+const RECOVERY_CRISIS_THRESHOLD: f64 = 10.0;
+/// Below this avg condition: Low intensity band.
+const LOW_INTENSITY_MAX: f64 = 40.0;
+/// Above this avg condition: High intensity band (40–70 inclusive is Medium).
+const HIGH_INTENSITY_MIN: f64 = 70.0;
+/// Fixture within this many days is considered "near match".
+const NEAR_MATCH_DAYS: i64 = 2;
+/// This many fixtures in the next 7 days counts as congested.
+const CONGESTION_FIXTURE_THRESHOLD: usize = 2;
+
+// ---------------------------------------------------------------------------
+// Style-biased weekly cycle
+// ---------------------------------------------------------------------------
+
+/// Returns a 5-slot weekly focus cycle for the given play style.
+///
+/// Indexed by `weekday_num % 5`:
+///   0 = Mon slot, 1 = Tue slot, 2 = Wed slot, 3 = Thu slot, 4 = Fri/Sat slot.
+///
+/// Balanced uses one of each focus.
+/// Every other style has 3 slots for its biased focus (2 extras vs the base).
+fn style_weekly_cycle(play_style: &PlayStyle) -> [TrainingFocus; 5] {
+    match play_style {
+        PlayStyle::Balanced => [
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Tactical,
+            TrainingFocus::Defending,
+            TrainingFocus::Attacking,
+        ],
+        PlayStyle::Attacking => [
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Attacking,
+            TrainingFocus::Attacking,
+            TrainingFocus::Attacking,
+        ],
+        PlayStyle::Defensive => [
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Defending,
+            TrainingFocus::Defending,
+            TrainingFocus::Defending,
+        ],
+        PlayStyle::Possession => [
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Tactical,
+            TrainingFocus::Tactical,
+            TrainingFocus::Tactical,
+        ],
+        PlayStyle::HighPress => [
+            TrainingFocus::Physical,
+            TrainingFocus::Physical,
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Tactical,
+        ],
+        PlayStyle::Counter => [
+            TrainingFocus::Physical,
+            TrainingFocus::Technical,
+            TrainingFocus::Technical,
+            TrainingFocus::Technical,
+            TrainingFocus::Tactical,
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn downgrade_intensity(intensity: TrainingIntensity) -> TrainingIntensity {
+    match intensity {
+        TrainingIntensity::High => TrainingIntensity::Medium,
+        TrainingIntensity::Medium | TrainingIntensity::Low => TrainingIntensity::Low,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-team snapshot (immutable read, no borrows retained)
+// ---------------------------------------------------------------------------
+
+struct TeamSnapshot {
+    avg_condition: f64,
+    days_to_next_fixture: i64,
+    fixtures_in_next_7: usize,
+    play_style: PlayStyle,
+    is_training_day: bool,
+}
+
+fn snapshot_team(game: &Game, team_id: &str, weekday_num: u32) -> TeamSnapshot {
+    let team = game.teams.iter().find(|t| t.id == team_id);
+    let (play_style, schedule) = team
+        .map(|t| (t.play_style.clone(), t.training_schedule.clone()))
+        .unwrap_or((PlayStyle::Balanced, domain::team::TrainingSchedule::Balanced));
+
+    let is_training_day = schedule.is_training_day(weekday_num);
+
+    let available_players: Vec<_> = game
+        .players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(team_id) && p.injury.is_none())
+        .collect();
+
+    let avg_condition = if available_players.is_empty() {
+        100.0
+    } else {
+        available_players.iter().map(|p| p.condition as f64).sum::<f64>()
+            / available_players.len() as f64
+    };
+
+    let today = game.clock.current_date.date_naive();
+    let (days_to_next, fixtures_in_next_7) = match &game.league {
+        None => (i64::MAX, 0),
+        Some(league) => {
+            let upcoming: Vec<i64> = league
+                .fixtures
+                .iter()
+                .filter(|f| {
+                    f.status == FixtureStatus::Scheduled
+                        && (f.home_team_id == team_id || f.away_team_id == team_id)
+                })
+                .filter_map(|f| NaiveDate::parse_from_str(&f.date, "%Y-%m-%d").ok())
+                .filter(|d| *d >= today)
+                .map(|d| (d - today).num_days())
+                .collect();
+
+            let days_to_next = upcoming.iter().copied().min().unwrap_or(i64::MAX);
+            let fixtures_in_next_7 = upcoming.iter().filter(|&&d| d <= 7).count();
+            (days_to_next, fixtures_in_next_7)
+        }
+    };
+
+    TeamSnapshot {
+        avg_condition,
+        days_to_next_fixture: days_to_next,
+        fixtures_in_next_7,
+        play_style,
+        is_training_day,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Compute and apply AI training decisions to every non-user team.
+///
+/// Must be called BEFORE `training::process_training` so that the planner's
+/// chosen focus and intensity are in effect when training effects are applied.
+pub fn apply_ai_training_policies(game: &mut Game, weekday_num: u32) {
+    let user_team_id = game.manager.team_id.clone();
+
+    // Collect AI team IDs up front to avoid borrow conflicts.
+    let team_ids: Vec<String> = game
+        .teams
+        .iter()
+        .filter(|t| Some(&t.id) != user_team_id.as_ref())
+        .map(|t| t.id.clone())
+        .collect();
+
+    for team_id in team_ids {
+        // Snapshot reads immutably and returns owned data — no borrow retained.
+        let snap = snapshot_team(game, &team_id, weekday_num);
+
+        // Rest day: no-op.
+        if !snap.is_training_day {
+            continue;
+        }
+
+        // Recovery crisis: full recovery day, cycle does NOT advance.
+        if snap.avg_condition < RECOVERY_CRISIS_THRESHOLD {
+            if let Some(team) = game.teams.iter_mut().find(|t| t.id == team_id) {
+                team.training_focus = TrainingFocus::Recovery;
+                team.training_intensity = TrainingIntensity::Low;
+            }
+            continue;
+        }
+
+        // Base intensity from condition band.
+        let base_intensity = if snap.avg_condition < LOW_INTENSITY_MAX {
+            TrainingIntensity::Low
+        } else if snap.avg_condition <= HIGH_INTENSITY_MIN {
+            TrainingIntensity::Medium
+        } else {
+            TrainingIntensity::High
+        };
+
+        let near_match = snap.days_to_next_fixture <= NEAR_MATCH_DAYS;
+        let congested = snap.fixtures_in_next_7 >= CONGESTION_FIXTURE_THRESHOLD;
+        let congestion_active = near_match || congested;
+
+        let intensity = if congestion_active {
+            downgrade_intensity(base_intensity)
+        } else {
+            base_intensity
+        };
+
+        // Style-biased weekly cycle; slot is based on weekday mod 5.
+        let cycle = style_weekly_cycle(&snap.play_style);
+        let slot = (weekday_num as usize) % 5;
+        let rotation_focus = cycle[slot].clone();
+
+        // Focus override based on effective intensity / congestion.
+        let focus = match &intensity {
+            // Low intensity (fatigue or congestion-downgraded) → recovery-first.
+            TrainingIntensity::Low => TrainingFocus::Recovery,
+            // Medium + congestion active → pre-match tactical work.
+            TrainingIntensity::Medium if congestion_active => TrainingFocus::Tactical,
+            // Healthy band → follow style-biased rotation.
+            _ => rotation_focus,
+        };
+
+        // V1 safety rule: Physical + High is the most punishing combination.
+        let intensity = if focus == TrainingFocus::Physical && intensity == TrainingIntensity::High {
+            TrainingIntensity::Medium
+        } else {
+            intensity
+        };
+
+        if let Some(team) = game.teams.iter_mut().find(|t| t.id == team_id) {
+            team.training_focus = focus;
+            team.training_intensity = intensity;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::GameClock;
+    use crate::game::Game;
+    use chrono::{TimeZone, Utc};
+    use domain::league::{Fixture, FixtureCompetition, FixtureStatus, League, StandingEntry};
+    use domain::manager::Manager;
+    use domain::player::{Player, PlayerAttributes, Position};
+    use domain::staff::{Staff, StaffAttributes, StaffRole};
+    use domain::team::{Team, TrainingFocus, TrainingIntensity, TrainingSchedule};
+
+    fn default_attrs() -> PlayerAttributes {
+        PlayerAttributes {
+            pace: 65,
+            stamina: 65,
+            strength: 65,
+            agility: 65,
+            passing: 65,
+            shooting: 65,
+            tackling: 65,
+            dribbling: 65,
+            defending: 65,
+            positioning: 65,
+            vision: 65,
+            decisions: 65,
+            composure: 65,
+            aggression: 50,
+            teamwork: 65,
+            leadership: 50,
+            handling: 20,
+            reflexes: 30,
+            aerial: 60,
+        }
+    }
+
+    fn make_player(id: &str, team_id: &str, condition: u8) -> Player {
+        let mut p = Player::new(
+            id.to_string(),
+            id.to_string(),
+            id.to_string(),
+            "1995-01-01".to_string(),
+            "ENG".to_string(),
+            Position::Midfielder,
+            default_attrs(),
+        );
+        p.team_id = Some(team_id.to_string());
+        p.condition = condition;
+        p
+    }
+
+    fn make_team(id: &str, play_style: PlayStyle) -> Team {
+        let mut t = Team::new(
+            id.to_string(),
+            id.to_string(),
+            id[..3.min(id.len())].to_string(),
+            "England".to_string(),
+            "London".to_string(),
+            "Stadium".to_string(),
+            40_000,
+        );
+        t.play_style = play_style;
+        t.training_schedule = TrainingSchedule::Balanced;
+        t.training_focus = TrainingFocus::Physical;
+        t.training_intensity = TrainingIntensity::Medium;
+        t
+    }
+
+    fn make_manager(team_id: Option<&str>) -> Manager {
+        let mut m = Manager::new(
+            "mgr1".to_string(),
+            "User".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "ENG".to_string(),
+        );
+        if let Some(tid) = team_id {
+            m.hire(tid.to_string());
+        }
+        m
+    }
+
+    fn make_game_with_two_teams(
+        user_team_id: &str,
+        ai_team_id: &str,
+        ai_play_style: PlayStyle,
+        ai_condition: u8,
+    ) -> Game {
+        // Monday 2026-06-15
+        let date = Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap();
+        let clock = GameClock::new(date);
+        let manager = make_manager(Some(user_team_id));
+
+        let user_team = make_team(user_team_id, PlayStyle::Balanced);
+        let mut ai_team = make_team(ai_team_id, ai_play_style);
+        ai_team.training_focus = TrainingFocus::Physical;
+        ai_team.training_intensity = TrainingIntensity::Medium;
+
+        let players: Vec<Player> = (0..5)
+            .flat_map(|i| {
+                vec![
+                    make_player(&format!("u{}", i), user_team_id, 80),
+                    make_player(&format!("a{}", i), ai_team_id, ai_condition),
+                ]
+            })
+            .collect();
+
+        Game::new(clock, manager, vec![user_team, ai_team], players, vec![], vec![])
+    }
+
+    // -----------------------------------------------------------------------
+    // Rest-day guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rest_day_does_not_change_ai_settings() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 80);
+        game.teams.iter_mut().find(|t| t.id == "ai").unwrap().training_focus =
+            TrainingFocus::Defending;
+
+        // Wednesday (2) is a rest day for Balanced schedule
+        apply_ai_training_policies(&mut game, 2);
+
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_focus, TrainingFocus::Defending, "rest day must not change focus");
+    }
+
+    // -----------------------------------------------------------------------
+    // User team guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn user_team_is_never_mutated() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 80);
+        game.teams.iter_mut().find(|t| t.id == "user").unwrap().training_focus =
+            TrainingFocus::Defending;
+        game.teams.iter_mut().find(|t| t.id == "user").unwrap().training_intensity =
+            TrainingIntensity::High;
+
+        // Monday (0) is a training day
+        apply_ai_training_policies(&mut game, 0);
+
+        let user = game.teams.iter().find(|t| t.id == "user").unwrap();
+        assert_eq!(user.training_focus, TrainingFocus::Defending);
+        assert_eq!(user.training_intensity, TrainingIntensity::High);
+    }
+
+    // -----------------------------------------------------------------------
+    // Recovery crisis (< 10)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn recovery_crisis_sets_recovery_focus_and_low_intensity() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 5);
+
+        apply_ai_training_policies(&mut game, 0); // Monday
+
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_focus, TrainingFocus::Recovery);
+        assert_eq!(ai.training_intensity, TrainingIntensity::Low);
+    }
+
+    // -----------------------------------------------------------------------
+    // Condition band → intensity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn avg_condition_39_gives_low_intensity() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 39);
+        apply_ai_training_policies(&mut game, 0);
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_intensity, TrainingIntensity::Low);
+    }
+
+    #[test]
+    fn avg_condition_40_gives_medium_intensity() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 40);
+        apply_ai_training_policies(&mut game, 0);
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_intensity, TrainingIntensity::Medium);
+    }
+
+    #[test]
+    fn avg_condition_71_gives_high_intensity() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 71);
+        // Use Tuesday (weekday 1, Balanced schedule trains Tue) → slot 1 = Technical.
+        // Technical + High does not trigger the safety rule, so intensity stays High.
+        apply_ai_training_policies(&mut game, 1);
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_intensity, TrainingIntensity::High);
+    }
+
+    // -----------------------------------------------------------------------
+    // Style-biased rotation on healthy squad
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn balanced_style_rotates_through_all_five_focuses() {
+        let focuses: Vec<TrainingFocus> = (0..5)
+            .map(|slot| style_weekly_cycle(&PlayStyle::Balanced)[slot].clone())
+            .collect();
+        assert!(focuses.contains(&TrainingFocus::Physical));
+        assert!(focuses.contains(&TrainingFocus::Technical));
+        assert!(focuses.contains(&TrainingFocus::Tactical));
+        assert!(focuses.contains(&TrainingFocus::Defending));
+        assert!(focuses.contains(&TrainingFocus::Attacking));
+    }
+
+    #[test]
+    fn attacking_style_has_three_attacking_slots() {
+        let cycle = style_weekly_cycle(&PlayStyle::Attacking);
+        let attacking_count = cycle.iter().filter(|f| **f == TrainingFocus::Attacking).count();
+        assert_eq!(attacking_count, 3);
+    }
+
+    #[test]
+    fn high_press_style_has_three_physical_slots() {
+        let cycle = style_weekly_cycle(&PlayStyle::HighPress);
+        let physical_count = cycle.iter().filter(|f| **f == TrainingFocus::Physical).count();
+        assert_eq!(physical_count, 3);
+    }
+
+    #[test]
+    fn counter_style_has_three_technical_slots() {
+        let cycle = style_weekly_cycle(&PlayStyle::Counter);
+        let technical_count = cycle.iter().filter(|f| **f == TrainingFocus::Technical).count();
+        assert_eq!(technical_count, 3);
+    }
+
+    #[test]
+    fn possession_style_has_three_tactical_slots() {
+        let cycle = style_weekly_cycle(&PlayStyle::Possession);
+        let tactical_count = cycle.iter().filter(|f| **f == TrainingFocus::Tactical).count();
+        assert_eq!(tactical_count, 3);
+    }
+
+    #[test]
+    fn defensive_style_has_three_defending_slots() {
+        let cycle = style_weekly_cycle(&PlayStyle::Defensive);
+        let defending_count = cycle.iter().filter(|f| **f == TrainingFocus::Defending).count();
+        assert_eq!(defending_count, 3);
+    }
+
+    #[test]
+    fn healthy_squad_attacking_style_uses_attacking_focus_on_slot2() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Attacking, 80);
+        // Slot 2 (weekday % 5 == 2) is Attacking for Attacking style
+        // weekday 2 = Wednesday; for Balanced schedule that's a rest day.
+        // Use weekday 7 % 5 = 2 to test slot logic without a rest-day veto.
+        // Actually we need a schedule that trains on Wed.
+        game.teams.iter_mut().find(|t| t.id == "ai").unwrap().training_schedule =
+            TrainingSchedule::Intense; // trains Mon-Sat
+
+        apply_ai_training_policies(&mut game, 2); // Wed slot = index 2
+
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_focus, TrainingFocus::Attacking);
+    }
+
+    // -----------------------------------------------------------------------
+    // V1 safety rule
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn physical_focus_with_high_intensity_is_downgraded_to_medium() {
+        // Condition 80 → High base intensity; slot 0 = Physical for any style
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 80);
+
+        apply_ai_training_policies(&mut game, 0); // Mon slot 0 = Physical
+
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        // Physical would normally get High, but safety rule caps it at Medium
+        assert_eq!(ai.training_focus, TrainingFocus::Physical);
+        assert_ne!(
+            ai.training_intensity,
+            TrainingIntensity::High,
+            "Physical + High must be blocked by safety rule"
+        );
+        assert_eq!(ai.training_intensity, TrainingIntensity::Medium);
+    }
+
+    // -----------------------------------------------------------------------
+    // Low intensity → Recovery focus
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn low_intensity_band_forces_recovery_focus() {
+        // Condition 25 → Low band (no fixture congestion)
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 25);
+        apply_ai_training_policies(&mut game, 1); // Tue
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        assert_eq!(ai.training_focus, TrainingFocus::Recovery);
+        assert_eq!(ai.training_intensity, TrainingIntensity::Low);
+    }
+
+    // -----------------------------------------------------------------------
+    // Congestion → Tactical focus + downgraded intensity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn congestion_downgrades_intensity_and_sets_tactical_focus() {
+        let mut game = make_game_with_two_teams("user", "ai", PlayStyle::Balanced, 80);
+
+        // Add 2 fixtures in the next 7 days for the AI team
+        let today_str = game.clock.current_date.format("%Y-%m-%d").to_string();
+        // today is 2026-06-15 (Mon); fixtures on +3 and +5 days
+        let fix1 = Fixture {
+            id: "f1".to_string(),
+            matchday: 1,
+            date: "2026-06-18".to_string(),
+            home_team_id: "ai".to_string(),
+            away_team_id: "other".to_string(),
+            competition: FixtureCompetition::League,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        };
+        let fix2 = Fixture {
+            id: "f2".to_string(),
+            matchday: 2,
+            date: "2026-06-20".to_string(),
+            home_team_id: "ai".to_string(),
+            away_team_id: "other2".to_string(),
+            competition: FixtureCompetition::League,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        };
+        let team_ids = vec!["ai".to_string()];
+        let mut league = League::new("league1".to_string(), "Test".to_string(), 1, &team_ids);
+        league.fixtures = vec![fix1, fix2];
+        game.league = Some(league);
+
+        apply_ai_training_policies(&mut game, 0); // Mon, healthy squad, but congested
+
+        let ai = game.teams.iter().find(|t| t.id == "ai").unwrap();
+        // High base → downgraded to Medium due to congestion, Tactical focus
+        assert_eq!(ai.training_focus, TrainingFocus::Tactical);
+        assert_eq!(ai.training_intensity, TrainingIntensity::Medium);
+    }
+}

--- a/src-tauri/crates/ofm_core/src/end_of_season.rs
+++ b/src-tauri/crates/ofm_core/src/end_of_season.rs
@@ -3,8 +3,10 @@ use crate::schedule::{append_fixtures, generate_league, generate_preseason_frien
 use crate::season_awards::compute_season_awards;
 use chrono::Duration;
 use domain::league::{FixtureStatus, League};
+use domain::manager::Manager;
 use domain::message::*;
 use domain::player::PlayerSeasonStats;
+use domain::staff::{Staff, StaffAttributes, StaffRole};
 use domain::team::{FinancialTransaction, FinancialTransactionKind, TeamSeasonRecord};
 
 pub fn expected_fixture_count(team_count: usize) -> Option<usize> {
@@ -263,6 +265,11 @@ pub fn process_end_of_season(game: &mut Game) -> EndOfSeasonSummary {
         player.stats = PlayerSeasonStats::default();
     }
 
+    // 5b. Convert retired players to unemployed manager/scout candidates, then
+    //     ensure the unemployed pools meet the season-end floor.
+    convert_retired_players_to_candidates(game);
+    crate::generator::replenish_manager_and_scout_market(game);
+
     // 6. Update manager career stats
     if let Some(standing) = &user_standing {
         let total_matches = standing.won + standing.drawn + standing.lost;
@@ -458,6 +465,124 @@ pub fn process_end_of_season(game: &mut Game) -> EndOfSeasonSummary {
     crate::season_context::refresh_game_context(game);
 
     summary
+}
+
+// ---------------------------------------------------------------------------
+// Retiree conversion
+// ---------------------------------------------------------------------------
+
+/// For every retired, unattached player with at least one career entry:
+/// * Creates an unemployed manager candidate with deterministic ID `mgr_retired_{player_id}`.
+/// * Creates an unattached scout with deterministic ID `staff_retired_scout_{player_id}`.
+///
+/// Both checks are idempotent — if the ID already exists the entry is not duplicated.
+fn convert_retired_players_to_candidates(game: &mut Game) {
+    // Snapshot eligible players (avoid holding borrows across mutations).
+    struct RetiredSnapshot {
+        player_id: String,
+        first_name: String,
+        last_name: String,
+        date_of_birth: String,
+        nationality: String,
+        ovr: u8,
+        career_len: usize,
+        vision: u8,
+        decisions: u8,
+        positioning: u8,
+        teamwork: u8,
+        leadership: u8,
+    }
+
+    let retirees: Vec<RetiredSnapshot> = game
+        .players
+        .iter()
+        .filter(|p| p.retired && p.team_id.is_none() && !p.career.is_empty())
+        .map(|p| {
+            let mut name_parts = p.full_name.splitn(2, ' ');
+            let first_name = name_parts.next().unwrap_or(&p.full_name).to_string();
+            let last_name = name_parts.next().unwrap_or("").to_string();
+            RetiredSnapshot {
+            player_id: p.id.clone(),
+            first_name,
+            last_name,
+            date_of_birth: p.date_of_birth.clone(),
+            nationality: p.nationality.clone(),
+            ovr: p.ovr,
+            career_len: p.career.len(),
+            vision: p.attributes.vision,
+            decisions: p.attributes.decisions,
+            positioning: p.attributes.positioning,
+            teamwork: p.attributes.teamwork,
+            leadership: p.attributes.leadership,
+            }
+        })
+        .collect();
+
+    if retirees.is_empty() {
+        return;
+    }
+
+    let existing_mgr_ids: std::collections::HashSet<String> =
+        game.managers.iter().map(|m| m.id.clone()).collect();
+    let existing_staff_ids: std::collections::HashSet<String> =
+        game.staff.iter().map(|s| s.id.clone()).collect();
+
+    let mut new_managers: Vec<Manager> = Vec::new();
+    let mut new_scouts: Vec<Staff> = Vec::new();
+
+    for r in &retirees {
+        // Manager candidate
+        let mgr_id = format!("mgr_retired_{}", r.player_id);
+        if !existing_mgr_ids.contains(&mgr_id) {
+            let reputation = (200u32)
+                .saturating_add((r.ovr as u32) * 6)
+                .saturating_add(r.career_len as u32 * 30)
+                .clamp(200, 900);
+
+            let mut mgr = Manager::new(
+                mgr_id,
+                r.first_name.clone(),
+                r.last_name.clone(),
+                r.date_of_birth.clone(),
+                r.nationality.clone(),
+            );
+            mgr.reputation = reputation;
+            mgr.satisfaction = 50;
+            mgr.fan_approval = 50;
+            // team_id stays None (unemployed)
+            new_managers.push(mgr);
+        }
+
+        // Scout candidate
+        let scout_id = format!("staff_retired_scout_{}", r.player_id);
+        if !existing_staff_ids.contains(&scout_id) {
+            let judging_ability =
+                ((r.vision as u16 + r.decisions as u16) / 2).min(100) as u8;
+            let judging_potential =
+                ((r.positioning as u16 + r.teamwork as u16) / 2).min(100) as u8;
+            let coaching = (r.leadership / 2).max(10);
+
+            let mut scout = Staff::new(
+                scout_id,
+                r.first_name.clone(),
+                r.last_name.clone(),
+                r.date_of_birth.clone(),
+                StaffRole::Scout,
+                StaffAttributes {
+                    coaching,
+                    judging_ability,
+                    judging_potential,
+                    physiotherapy: 10,
+                },
+            );
+            scout.nationality = r.nationality.clone();
+            // team_id stays None (unattached market candidate)
+            new_scouts.push(scout);
+        }
+    }
+
+    game.managers.extend(new_managers);
+    game.staff.extend(new_scouts);
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]

--- a/src-tauri/crates/ofm_core/src/generator/generation.rs
+++ b/src-tauri/crates/ofm_core/src/generator/generation.rs
@@ -420,11 +420,12 @@ pub(super) fn generate_random_staff_unattached_from_def(
 pub(super) fn generate_random_unemployed_manager(
     nationality: &str,
     names_def: &NamesDefinition,
+    current_year: u32,
     rng: &mut impl Rng,
 ) -> domain::manager::Manager {
     let (first_name, last_name) = pick_name_from_def(nationality, names_def, rng);
     let age: u32 = rng.random_range(35..65);
-    let birth_year = 2026u32.saturating_sub(age);
+    let birth_year = current_year.saturating_sub(age);
     let dob = format!(
         "{:04}-{:02}-{:02}",
         birth_year,

--- a/src-tauri/crates/ofm_core/src/generator/generation.rs
+++ b/src-tauri/crates/ofm_core/src/generator/generation.rs
@@ -414,3 +414,34 @@ pub(super) fn generate_random_staff_unattached_from_def(
     s.nationality = nationality.to_string();
     s
 }
+
+/// Generate a random unemployed manager (no team) using the provided name pool.
+/// Used to top up the unemployed manager market when below the seasonal floor.
+pub(super) fn generate_random_unemployed_manager(
+    nationality: &str,
+    names_def: &NamesDefinition,
+    rng: &mut impl Rng,
+) -> domain::manager::Manager {
+    let (first_name, last_name) = pick_name_from_def(nationality, names_def, rng);
+    let age: u32 = rng.random_range(35..65);
+    let birth_year = 2026u32.saturating_sub(age);
+    let dob = format!(
+        "{:04}-{:02}-{:02}",
+        birth_year,
+        rng.random_range(1u32..13u32),
+        rng.random_range(1u32..29u32)
+    );
+    let reputation = rng.random_range(200u32..=700u32);
+
+    let mut mgr = domain::manager::Manager::new(
+        Uuid::new_v4().to_string(),
+        first_name,
+        last_name,
+        dob,
+        nationality.to_string(),
+    );
+    mgr.reputation = reputation;
+    mgr.satisfaction = 50;
+    mgr.fan_approval = 50;
+    mgr
+}

--- a/src-tauri/crates/ofm_core/src/generator/mod.rs
+++ b/src-tauri/crates/ofm_core/src/generator/mod.rs
@@ -15,6 +15,7 @@ use rand::RngExt;
 use uuid::Uuid;
 
 use generation::*;
+use chrono::Datelike;
 
 const MAX_OPENING_EXPIRING_CONTRACTS: usize = 2;
 const MIN_OPENING_RUNWAY_WEEKS: i64 = 16;
@@ -394,6 +395,7 @@ pub fn replenish_manager_and_scout_market(game: &mut crate::game::Game) {
     if unemployed_mgr_count < floor {
         let needed = floor - unemployed_mgr_count;
         let (names_def, country_codes) = create_staff_generator_context();
+        let current_year = game.clock.current_date.year() as u32;
         let mut rng = rand::rng();
         for _ in 0..needed {
             let nationality = if country_codes.is_empty() {
@@ -402,8 +404,12 @@ pub fn replenish_manager_and_scout_market(game: &mut crate::game::Game) {
                 let idx = rng.random_range(0..country_codes.len());
                 country_codes[idx].clone()
             };
-            let mgr =
-                generation::generate_random_unemployed_manager(&nationality, &names_def, &mut rng);
+            let mgr = generation::generate_random_unemployed_manager(
+                &nationality,
+                &names_def,
+                current_year,
+                &mut rng,
+            );
             game.managers.push(mgr);
         }
     }

--- a/src-tauri/crates/ofm_core/src/generator/mod.rs
+++ b/src-tauri/crates/ofm_core/src/generator/mod.rs
@@ -369,6 +369,74 @@ pub fn process_available_staff_market(game: &mut crate::game::Game) -> bool {
     true
 }
 
+/// Ensure the unemployed manager and scout pools each meet a floor of `team_count * 2`.
+///
+/// Called at the end of every season after retiree conversion so there are always
+/// enough candidates for the player to consider hiring.  The function only adds
+/// entries — it never removes any.
+pub fn replenish_manager_and_scout_market(game: &mut crate::game::Game) {
+    let team_count = game.teams.len();
+    let floor = team_count * 2;
+
+    let user_manager_id = if game.manager_id.is_empty() {
+        game.manager.id.clone()
+    } else {
+        game.manager_id.clone()
+    };
+
+    // --- Managers ---
+    let unemployed_mgr_count = game
+        .managers
+        .iter()
+        .filter(|m| m.id != user_manager_id && m.team_id.is_none())
+        .count();
+
+    if unemployed_mgr_count < floor {
+        let needed = floor - unemployed_mgr_count;
+        let (names_def, country_codes) = create_staff_generator_context();
+        let mut rng = rand::rng();
+        for _ in 0..needed {
+            let nationality = if country_codes.is_empty() {
+                "ENG".to_string()
+            } else {
+                let idx = rng.random_range(0..country_codes.len());
+                country_codes[idx].clone()
+            };
+            let mgr =
+                generation::generate_random_unemployed_manager(&nationality, &names_def, &mut rng);
+            game.managers.push(mgr);
+        }
+    }
+
+    // --- Scouts ---
+    let unemployed_scout_count = game
+        .staff
+        .iter()
+        .filter(|s| s.team_id.is_none() && matches!(s.role, StaffRole::Scout))
+        .count();
+
+    if unemployed_scout_count < floor {
+        let needed = floor - unemployed_scout_count;
+        let (names_def, country_codes) = create_staff_generator_context();
+        let mut rng = rand::rng();
+        for _ in 0..needed {
+            let nationality = if country_codes.is_empty() {
+                "ENG".to_string()
+            } else {
+                let idx = rng.random_range(0..country_codes.len());
+                country_codes[idx].clone()
+            };
+            let scout = generate_random_staff_unattached_from_def(
+                StaffRole::Scout,
+                &nationality,
+                &names_def,
+                &mut rng,
+            );
+            game.staff.push(scout);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // World generation
 // ---------------------------------------------------------------------------

--- a/src-tauri/crates/ofm_core/src/lib.rs
+++ b/src-tauri/crates/ofm_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod aging;
 pub mod ai_hiring;
+pub mod ai_training;
 pub mod board_objectives;
 pub mod clock;
 pub mod club;

--- a/src-tauri/crates/ofm_core/src/turn/mod.rs
+++ b/src-tauri/crates/ofm_core/src/turn/mod.rs
@@ -59,6 +59,7 @@ where
         simulate_matchday_with_capture(game, &today, on_capture);
     } else {
         let weekday_num = game.clock.current_date.weekday().num_days_from_monday();
+        crate::ai_training::apply_ai_training_policies(game, weekday_num);
         training::process_training(game, weekday_num);
         training::check_squad_fitness_warnings(game);
     }

--- a/src-tauri/crates/ofm_core/tests/end_of_season_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/end_of_season_tests.rs
@@ -1262,3 +1262,216 @@ fn season_end_board_message_top_four_uses_correct_body_key() {
         "topFour key must include suffix param"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Retiree conversion and pool replenishment
+// ---------------------------------------------------------------------------
+
+fn make_retired_player(id: &str) -> domain::player::Player {
+    use domain::player::{CareerEntry, PlayerAttributes, Position};
+    let attrs = PlayerAttributes {
+        pace: 55,
+        stamina: 55,
+        strength: 55,
+        agility: 55,
+        passing: 70,
+        shooting: 60,
+        tackling: 65,
+        dribbling: 60,
+        defending: 65,
+        positioning: 72,
+        vision: 74,
+        decisions: 70,
+        composure: 65,
+        aggression: 50,
+        teamwork: 68,
+        leadership: 60,
+        handling: 20,
+        reflexes: 20,
+        aerial: 55,
+    };
+    let mut p = domain::player::Player::new(
+        id.to_string(),
+        format!("{} Ret", id),
+        format!("Full {}", id),
+        "1988-01-01".to_string(),
+        "ENG".to_string(),
+        Position::Midfielder,
+        attrs,
+    );
+    p.team_id = None;
+    p.retired = true;
+    p.career.push(CareerEntry {
+        season: 1,
+        team_id: "team1".to_string(),
+        team_name: "Test FC".to_string(),
+        appearances: 30,
+        goals: 5,
+        assists: 8,
+    });
+    p
+}
+
+#[test]
+fn retired_player_creates_manager_candidate_with_deterministic_id() {
+    let mut game = make_completed_season_game();
+    game.players.push(make_retired_player("retiree1"));
+
+    process_end_of_season(&mut game);
+
+    let mgr_id = "mgr_retired_retiree1";
+    assert!(
+        game.managers.iter().any(|m| m.id == mgr_id),
+        "unemployed manager with id '{}' should exist after season end",
+        mgr_id
+    );
+}
+
+#[test]
+fn retired_player_creates_scout_candidate_with_deterministic_id() {
+    let mut game = make_completed_season_game();
+    game.players.push(make_retired_player("retiree2"));
+
+    process_end_of_season(&mut game);
+
+    let scout_id = "staff_retired_scout_retiree2";
+    assert!(
+        game.staff
+            .iter()
+            .any(|s| s.id == scout_id
+                && matches!(s.role, domain::staff::StaffRole::Scout)
+                && s.team_id.is_none()),
+        "unattached scout '{}' should exist after season end",
+        scout_id
+    );
+}
+
+#[test]
+fn retiree_conversion_is_idempotent() {
+    let mut game = make_completed_season_game();
+    game.players.push(make_retired_player("idem1"));
+
+    process_end_of_season(&mut game);
+    // Build a fresh completed-season state and re-trigger (simulates second season)
+    // Manually reset enough state so process_end_of_season can run again
+    if let Some(league) = &mut game.league {
+        // Mark new season fixtures as completed for the guard check
+        for f in league.fixtures.iter_mut() {
+            f.status = domain::league::FixtureStatus::Completed;
+            f.result = Some(domain::league::MatchResult {
+                home_goals: 1,
+                away_goals: 0,
+                home_scorers: vec![],
+                away_scorers: vec![],
+                report: None,
+            });
+        }
+    }
+    process_end_of_season(&mut game);
+
+    let mgr_count = game
+        .managers
+        .iter()
+        .filter(|m| m.id == "mgr_retired_idem1")
+        .count();
+    assert_eq!(mgr_count, 1, "duplicate manager must not be created on second call");
+
+    let scout_count = game
+        .staff
+        .iter()
+        .filter(|s| s.id == "staff_retired_scout_idem1")
+        .count();
+    assert_eq!(scout_count, 1, "duplicate scout must not be created on second call");
+}
+
+#[test]
+fn retired_player_with_no_career_is_not_converted() {
+    let mut game = make_completed_season_game();
+    let mut p = make_retired_player("no_career");
+    p.career.clear(); // ineligible
+    game.players.push(p);
+
+    process_end_of_season(&mut game);
+
+    assert!(
+        !game.managers.iter().any(|m| m.id == "mgr_retired_no_career"),
+        "players with no career entries must not become manager candidates"
+    );
+}
+
+#[test]
+fn manager_pool_is_topped_up_to_floor_after_season() {
+    let mut game = make_completed_season_game();
+    let team_count = game.teams.len(); // 2 teams → floor = 4
+
+    process_end_of_season(&mut game);
+
+    let user_mgr_id = game.manager.id.clone();
+    let unemployed = game
+        .managers
+        .iter()
+        .filter(|m| m.id != user_mgr_id && m.team_id.is_none())
+        .count();
+    assert!(
+        unemployed >= team_count * 2,
+        "unemployed manager pool ({}) should be >= floor ({})",
+        unemployed,
+        team_count * 2
+    );
+}
+
+#[test]
+fn scout_pool_is_topped_up_to_floor_after_season() {
+    let mut game = make_completed_season_game();
+    let team_count = game.teams.len(); // 2 teams → floor = 4
+
+    process_end_of_season(&mut game);
+
+    let unemployed_scouts = game
+        .staff
+        .iter()
+        .filter(|s| s.team_id.is_none() && matches!(s.role, domain::staff::StaffRole::Scout))
+        .count();
+    assert!(
+        unemployed_scouts >= team_count * 2,
+        "unemployed scout pool ({}) should be >= floor ({})",
+        unemployed_scouts,
+        team_count * 2
+    );
+}
+
+#[test]
+fn retiree_manager_reputation_is_derived_from_ovr_and_career() {
+    let mut game = make_completed_season_game();
+    game.players.push(make_retired_player("ovr_test"));
+
+    process_end_of_season(&mut game);
+
+    let mgr = game
+        .managers
+        .iter()
+        .find(|m| m.id == "mgr_retired_ovr_test")
+        .expect("manager should exist");
+    assert!(mgr.reputation >= 200, "reputation should be >= 200");
+    assert!(mgr.reputation <= 900, "reputation should be <= 900");
+    assert_eq!(mgr.satisfaction, 50);
+    assert_eq!(mgr.fan_approval, 50);
+}
+
+#[test]
+fn retiree_scout_judging_attributes_derived_from_player_attrs() {
+    let mut game = make_completed_season_game();
+    game.players.push(make_retired_player("attr_test"));
+
+    process_end_of_season(&mut game);
+
+    let scout = game
+        .staff
+        .iter()
+        .find(|s| s.id == "staff_retired_scout_attr_test")
+        .expect("scout should exist");
+    // vision=74, decisions=70 → judging_ability = (74+70)/2 = 72
+    assert_eq!(scout.attributes.judging_ability, 72);
+    // positioning=72, teamwork=68 → judging_potential = (72+68)/2 = 70
+    assert_eq!(scout.attributes.judging_potential, 70);
+}


### PR DESCRIPTION
- Added functionality to convert retired players into unemployed manager and scout candidates at the end of the season.
- Implemented logic to ensure the unemployed manager and scout pools meet a minimum threshold.
- Introduced AI training policies for non-user teams, adjusting training focus and intensity based on player conditions and fixture schedules.
- Added unit tests to verify retiree conversion and pool replenishment functionalities.

-I believe I followed all the guidelines if I added too much code, let me know and I'll rework it if needed. All tests passed.
-First time contributing to a project like this so if you have feedback, I am open to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI teams now receive automated daily training decisions using condition-based intensity bands, congestion/near-match handling, and a style-biased weekly focus cycle (with rest-day and user-team safeguards)
  * Added end-of-season conversion of eligible retired, unattached players into unemployed manager and scout candidates
  * Automatically replenishes unemployed manager and scout markets to maintain target supply
* **Tests**
  * Added comprehensive coverage for training policy behavior, including safety downgrades and focus overrides, plus end-of-season conversion and replenishment idempotency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->