### PR TITLE
fix: Make sure live game results get committed

### DIFF
--- a/src-tauri/src/application/live_match.rs
+++ b/src-tauri/src/application/live_match.rs
@@ -50,6 +50,16 @@ pub fn finish_live_match(state: &StateManager) -> Result<FinishLiveMatchResponse
         state.append_stats_state(capture);
     }
 
+    // apply_match_report_with_capture mutates the legacy `game.league` mirror
+    // (fixture status, fixture.result, standings). The modern `game.competitions`
+    // is the source of truth, and finish_live_match_day's sync_legacy_league
+    // would otherwise overwrite our changes with the stale competition copy.
+    if let Some(league) = game.league.clone() {
+        if let Some(idx) = game.competitions.iter().position(|c| c.id == league.id) {
+            game.competitions[idx] = league;
+        }
+    }
+
     let round_summary = build_round_summary_dto(&game, round_matchday, &round_previous_standings);
 
     ofm_core::turn::finish_live_match_day(&mut game);

--- a/src-tauri/src/commands/live_match.rs
+++ b/src-tauri/src/commands/live_match.rs
@@ -432,7 +432,11 @@ mod tests {
         };
 
         let mut game = Game::new(clock, manager, teams, players, vec![], vec![]);
-        game.league = Some(league);
+        game.league = Some(league.clone());
+        // `game.competitions` is the modern source of truth; the legacy `league`
+        // field is only a mirror. Real saves always have both populated, so the
+        // test fixture mirrors that to exercise sync_legacy_league realistically.
+        game.competitions = vec![league];
         game
     }
 
@@ -442,6 +446,73 @@ mod tests {
             .find(|result| result["player_id"] == player_id)
             .and_then(|result| result["delta"].as_i64())
             .unwrap()
+    }
+
+    #[test]
+    fn finish_live_match_persists_user_standings_update() {
+        // Regression: finish_live_match_day calls sync_legacy_league at the end,
+        // which copies game.competitions[i] back into game.league. If
+        // apply_match_report's standings/fixture update only landed on the legacy
+        // mirror, the sync silently wipes it out — leaving the user's team with
+        // played=0 in the table even though the result mail was sent.
+        let state = StateManager::new();
+        let game = make_game_with_round();
+
+        let mut session =
+            live_match_manager::create_live_match(&game, 0, MatchMode::Instant, false).unwrap();
+        session.user_side = None;
+        session.run_to_completion();
+
+        state.set_game(game);
+        state.set_live_match(session);
+
+        finish_live_match_internal(&state).expect("finish live match response");
+
+        // Assert against the persisted state — not just the cloned response.game
+        // — so a missing state.set_game() call would surface here.
+        let persisted_game = state
+            .get_game(|game| game.clone())
+            .expect("game persisted in state after finish_live_match_internal");
+
+        let competition = persisted_game
+            .competitions
+            .first()
+            .expect("user competition retained");
+        let user_entry = competition
+            .standings
+            .iter()
+            .find(|entry| entry.team_id == "team1")
+            .expect("user team standings entry");
+        assert_eq!(
+            user_entry.played, 1,
+            "user team must have played count incremented after live match",
+        );
+        let opp_entry = competition
+            .standings
+            .iter()
+            .find(|entry| entry.team_id == "team2")
+            .expect("opponent team standings entry");
+        assert_eq!(opp_entry.played, 1, "opponent played count must also update");
+        assert_eq!(
+            user_entry.points + opp_entry.points,
+            user_entry.won * 3
+                + opp_entry.won * 3
+                + (user_entry.drawn + opp_entry.drawn),
+            "points must agree with W/D record",
+        );
+
+        let user_fixture = competition
+            .fixtures
+            .first()
+            .expect("user fixture retained");
+        assert!(
+            matches!(user_fixture.status, domain::league::FixtureStatus::Completed),
+            "user fixture must be marked Completed",
+        );
+        assert!(
+            user_fixture.result.is_some(),
+            "user fixture result must be recorded",
+        );
     }
 
     #[test]

--- a/src/pages/MatchSimulation.tsx
+++ b/src/pages/MatchSimulation.tsx
@@ -112,6 +112,10 @@ export default function MatchSimulation() {
 
   // Fetch initial snapshot
   useEffect(() => {
+    // Don't refetch after finalize — finish_live_match has cleared the backend
+    // session, so get_match_snapshot would fail and the catch path would
+    // start_live_match a fresh 0-0 session, clobbering the final score.
+    if (hasFinalizedMatch) return;
     let isCancelled = false;
 
     const fetchSnapshot = async () => {
@@ -183,7 +187,7 @@ export default function MatchSimulation() {
     return () => {
       isCancelled = true;
     };
-  }, [gameState, matchMode, navigate, routeState?.fixtureIndex, routeState?.snapshot]);
+  }, [hasFinalizedMatch, gameState, matchMode, navigate, routeState?.fixtureIndex, routeState?.snapshot]);
 
   // Skip pre-match for spectators
   useEffect(() => {


### PR DESCRIPTION
Great game!

I played and noticed that when I have a live game, the results do not get committed. Even though games had goals, the game result page showed 0-0 and tables did not get updated.

Warning: I did not looked at the code, I just explained the bug to claude to fix it. I do not know Rust. I am happy to improve my patch if its messed up. Just let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live match finalization to reconcile league/competition data with the persisted game state, preventing competition entries from becoming stale.
  * Prevented finalized match simulations from reloading an old snapshot after match completion, avoiding inconsistencies in the UI.
  * Improved reliability of live-match finishing so results and standings are saved correctly.
* **Tests**
  * Added a regression test to verify persisted standings and match results after a live match is finished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->