### PR TITLE
fix(staff): read camelCase judging attributes from the backend

### DIFF
--- a/src/components/playerProfile/PlayerProfile.scouting.test.ts
+++ b/src/components/playerProfile/PlayerProfile.scouting.test.ts
@@ -16,8 +16,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
         role: "Scout",
         attributes: {
             coaching: 10,
-            judging_ability: 14,
-            judging_potential: 13,
+            judgingAbility: 14,
+            judgingPotential: 13,
             physiotherapy: 1,
         },
         team_id: "team-1",

--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -295,8 +295,8 @@ function createStaff(overrides: Partial<StaffData> = {}): StaffData {
     role: "AssistantManager" as const,
     attributes: {
       coaching: 70,
-      judging_ability: 60,
-      judging_potential: 60,
+      judgingAbility: 60,
+      judgingPotential: 60,
       physiotherapy: 20,
     },
     team_id: "team-1",

--- a/src/components/playerProfile/PlayerProfileScoutAction.test.tsx
+++ b/src/components/playerProfile/PlayerProfileScoutAction.test.tsx
@@ -26,8 +26,8 @@ describe("PlayerProfileScoutAction", () => {
         role: "Scout",
         attributes: {
             coaching: 0,
-            judging_ability: 14,
-            judging_potential: 15,
+            judgingAbility: 14,
+            judgingPotential: 15,
             physiotherapy: 0,
         },
         team_id: "team-1",

--- a/src/components/players/PlayersListTab.test.tsx
+++ b/src/components/players/PlayersListTab.test.tsx
@@ -190,8 +190,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/components/scouting/ScoutingAssignmentsList.test.tsx
+++ b/src/components/scouting/ScoutingAssignmentsList.test.tsx
@@ -134,8 +134,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/components/scouting/ScoutingOverviewCards.test.tsx
+++ b/src/components/scouting/ScoutingOverviewCards.test.tsx
@@ -14,8 +14,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",
@@ -31,8 +31,8 @@ describe("ScoutingOverviewCards", () => {
     render(
       <ScoutingOverviewCards
         scouts={[
-          createScout({ id: "staff-1", attributes: { coaching: 20, judging_ability: 65, judging_potential: 70, physiotherapy: 10 } }),
-          createScout({ id: "staff-2", attributes: { coaching: 20, judging_ability: 80, judging_potential: 75, physiotherapy: 10 } }),
+          createScout({ id: "staff-1", attributes: { coaching: 20, judgingAbility: 65, judgingPotential: 70, physiotherapy: 10 } }),
+          createScout({ id: "staff-2", attributes: { coaching: 20, judgingAbility: 80, judgingPotential: 75, physiotherapy: 10 } }),
         ]}
         assignmentCount={3}
         availableScoutCount={1}

--- a/src/components/scouting/ScoutingScoutDetailsCard.test.tsx
+++ b/src/components/scouting/ScoutingScoutDetailsCard.test.tsx
@@ -34,8 +34,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/components/scouting/ScoutingScoutDetailsCard.tsx
+++ b/src/components/scouting/ScoutingScoutDetailsCard.tsx
@@ -34,7 +34,7 @@ export default function ScoutingScoutDetailsCard({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {scouts.map((scout) => {
             const count = scoutAssignmentCount(assignments, scout.id);
-            const maxSlots = scoutMaxSlots(scout.attributes.judging_ability);
+            const maxSlots = scoutMaxSlots(scout.attributes.judgingAbility);
             const isFull = count >= maxSlots;
             const scoutAssignments = assignments.filter(
               (assignment) => assignment.scout_id === scout.id,
@@ -72,7 +72,7 @@ export default function ScoutingScoutDetailsCard({
                       {t("scouting.judgingAbility")}
                     </p>
                     <ProgressBar
-                      value={scout.attributes.judging_ability}
+                      value={scout.attributes.judgingAbility}
                       variant="auto"
                       size="sm"
                     />
@@ -82,7 +82,7 @@ export default function ScoutingScoutDetailsCard({
                       {t("scouting.judgingPotential")}
                     </p>
                     <ProgressBar
-                      value={scout.attributes.judging_potential}
+                      value={scout.attributes.judgingPotential}
                       variant="auto"
                       size="sm"
                     />

--- a/src/components/scouting/ScoutingTab.helpers.test.ts
+++ b/src/components/scouting/ScoutingTab.helpers.test.ts
@@ -17,8 +17,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",
@@ -63,8 +63,8 @@ describe("ScoutingTab.helpers", () => {
 
   it("returns only scouts without an active assignment", () => {
     const scouts = [
-      createScout({ id: "staff-1", attributes: { coaching: 20, judging_ability: 20, judging_potential: 70, physiotherapy: 10 } }),
-      createScout({ id: "staff-2", attributes: { coaching: 20, judging_ability: 80, judging_potential: 70, physiotherapy: 10 } }),
+      createScout({ id: "staff-1", attributes: { coaching: 20, judgingAbility: 20, judgingPotential: 70, physiotherapy: 10 } }),
+      createScout({ id: "staff-2", attributes: { coaching: 20, judgingAbility: 80, judgingPotential: 70, physiotherapy: 10 } }),
     ];
     const assignments = [
       createAssignment({ id: "a1", scout_id: "staff-1" }),

--- a/src/components/scouting/ScoutingTab.helpers.ts
+++ b/src/components/scouting/ScoutingTab.helpers.ts
@@ -21,6 +21,6 @@ export function calculateAvailableScouts(
   return scouts.filter(
     (scout) =>
       scoutAssignmentCount(assignments, scout.id) <
-      scoutMaxSlots(scout.attributes.judging_ability),
+      scoutMaxSlots(scout.attributes.judgingAbility),
   );
 }

--- a/src/components/scouting/ScoutingTab.test.tsx
+++ b/src/components/scouting/ScoutingTab.test.tsx
@@ -207,8 +207,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/components/scouting/ScoutingTab.tsx
+++ b/src/components/scouting/ScoutingTab.tsx
@@ -215,7 +215,7 @@ export default function ScoutingTab({
         assignmentCount={allAssignments.length}
         availableScoutCount={availableScouts.length}
         totalCapacity={scouts.reduce(
-          (sum, scout) => sum + scoutMaxSlots(scout.attributes.judging_ability),
+          (sum, scout) => sum + scoutMaxSlots(scout.attributes.judgingAbility),
           0,
         )}
         labels={{

--- a/src/components/staff/StaffTab.test.tsx
+++ b/src/components/staff/StaffTab.test.tsx
@@ -78,8 +78,8 @@ function createStaff(overrides: Partial<StaffData> = {}): StaffData {
     role: "Coach",
     attributes: {
       coaching: 70,
-      judging_ability: 50,
-      judging_potential: 55,
+      judgingAbility: 50,
+      judgingPotential: 55,
       physiotherapy: 30,
     },
     team_id: "team-1",
@@ -248,6 +248,36 @@ describe("StaffTab", () => {
       expect(invokeMock).toHaveBeenCalledWith("release_staff", { staffId: "staff-1" });
       expect(onGameUpdate).toHaveBeenCalledWith(updatedState);
     });
+  });
+
+  it("renders judging attribute values when backend sends camelCase keys", async () => {
+    // Regression: domain::StaffAttributes serializes as camelCase
+    // (judgingAbility / judgingPotential); the frontend used to read
+    // snake_case → values came back undefined, OVR rendered as "NaN OVR" and
+    // the AttrBar showed no number with a full-width bar. See commit 09d33244.
+    const staffCamelCase = createStaff({
+      attributes: { coaching: 63, judgingAbility: 52, judgingPotential: 71, physiotherapy: 44 },
+    });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "get_staff") {
+        return {
+          team_staff: [staffCamelCase],
+          available_staff: [],
+          scouting_assignments: [],
+          youth_scouting_assignments: [],
+        };
+      }
+      return createGameState([]);
+    });
+
+    render(<StaffTab gameState={createGameState([])} />);
+
+    const card = await screen.findByTestId("staff-card-staff-1");
+    // OVR = (63+52+71+44)/4 = 57.5 → 58
+    expect(within(card).getByText("58 OVR")).toBeInTheDocument();
+    expect(within(card).getByText("52")).toBeInTheDocument();
+    expect(within(card).getByText("71")).toBeInTheDocument();
+    expect(within(card).getByText(/judgingPotential \(71\)/)).toBeInTheDocument();
   });
 
   it("shows scout workload details and opens the scouting workflow", async () => {

--- a/src/components/staff/StaffTab.tsx
+++ b/src/components/staff/StaffTab.tsx
@@ -47,8 +47,8 @@ const ROLE_COLORS: Record<string, string> = {
 function bestAttr(s: StaffData): { key: string; value: number } {
   const attrs = [
     { key: "coaching", value: s.attributes.coaching },
-    { key: "judgingAbility", value: s.attributes.judging_ability },
-    { key: "judgingPotential", value: s.attributes.judging_potential },
+    { key: "judgingAbility", value: s.attributes.judgingAbility },
+    { key: "judgingPotential", value: s.attributes.judgingPotential },
     { key: "physiotherapy", value: s.attributes.physiotherapy },
   ];
   return attrs.reduce((a, b) => (b.value > a.value ? b : a));
@@ -57,8 +57,8 @@ function bestAttr(s: StaffData): { key: string; value: number } {
 function ovrRating(s: StaffData): number {
   return Math.round(
     (s.attributes.coaching +
-      s.attributes.judging_ability +
-      s.attributes.judging_potential +
+      s.attributes.judgingAbility +
+      s.attributes.judgingPotential +
       s.attributes.physiotherapy) /
     4,
   );
@@ -336,11 +336,11 @@ export default function StaffTab({ gameState, onGameUpdate, onNavigate }: StaffT
                           />
                           <AttrBar
                             label={t("staff.attrs.judgingAbility")}
-                            value={staff.attributes.judging_ability}
+                            value={staff.attributes.judgingAbility}
                           />
                           <AttrBar
                             label={t("staff.attrs.judgingPotential")}
-                            value={staff.attributes.judging_potential}
+                            value={staff.attributes.judgingPotential}
                           />
                           <AttrBar
                             label={t("staff.attrs.physiotherapy")}

--- a/src/components/transfers/TransfersTab.test.tsx
+++ b/src/components/transfers/TransfersTab.test.tsx
@@ -344,8 +344,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/components/youthAcademy/YouthAcademyTab.test.tsx
+++ b/src/components/youthAcademy/YouthAcademyTab.test.tsx
@@ -220,8 +220,8 @@ function createScout(overrides: Partial<StaffData> = {}): StaffData {
     role: "Scout",
     attributes: {
       coaching: 20,
-      judging_ability: 65,
-      judging_potential: 70,
+      judgingAbility: 65,
+      judgingPotential: 70,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/lib/finance.test.ts
+++ b/src/lib/finance.test.ts
@@ -112,8 +112,8 @@ function createStaff(overrides: Partial<StaffData> = {}): StaffData {
     role: "Coach",
     attributes: {
       coaching: 10,
-      judging_ability: 10,
-      judging_potential: 10,
+      judgingAbility: 10,
+      judgingPotential: 10,
       physiotherapy: 10,
     },
     team_id: "team-1",

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -154,8 +154,8 @@ describe("useGameStore", () => {
             role: "Coach",
             attributes: {
               coaching: 70,
-              judging_ability: 70,
-              judging_potential: 70,
+              judgingAbility: 70,
+              judgingPotential: 70,
               physiotherapy: 30,
             },
             team_id: "team1",

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -352,8 +352,8 @@ export interface StaffData {
   role: "AssistantManager" | "Coach" | "Scout" | "Physio";
   attributes: {
     coaching: number;
-    judging_ability: number;
-    judging_potential: number;
+    judgingAbility: number;
+    judgingPotential: number;
     physiotherapy: number;
   };
   team_id: string | null;


### PR DESCRIPTION
domain::StaffAttributes serializes as camelCase (judgingAbility / judgingPotential) since 09d33244, but the frontend StaffData type and all read sites still used snake_case keys. The two single-word fields (coaching, physiotherapy) survived because their casing is identical; judging_ability / judging_potential came back undefined, producing "NaN OVR" and bare full-width AttrBars on the staff cards.

Align the TS shape with the wire format: rename StaffData.attributes keys to camelCase and update the four read sites (StaffTab, ScoutingTab, ScoutingTab.helpers, ScoutingScoutDetailsCard). Migrate the staff fixtures across 13 test files so mocks now reflect what the backend actually sends — the snake_case fixtures were how this regression got past review.

Adds a StaffTab regression test that mocks get_staff with camelCase attributes and asserts the OVR badge and judging values render.

Before: 
<img width="962" height="463" alt="grafik" src="https://github.com/user-attachments/assets/adc1a637-4c52-4dbb-82c4-47c7f2668485" />

After:
<img width="1596" height="459" alt="grafik" src="https://github.com/user-attachments/assets/b7ff62ed-bbc7-41d6-a7e1-02ed2841e476" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scouting and staff displays to use the correct judging attribute values, improving overall ratings, slot calculations, and progress bars.
  * Fixed several screens and workflows so scout-related information appears consistently across player profiles, scouting, transfers, youth academy, and finance-related views.
  * Added coverage to prevent regressions when loading and rendering staff data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->