### PR TITLE
fix(scouting): allow scouting youth goalkeepers

### DIFF
--- a/src-tauri/crates/ofm_core/src/generator/generation.rs
+++ b/src-tauri/crates/ofm_core/src/generator/generation.rs
@@ -171,9 +171,10 @@ pub(super) fn generate_random_player_from_def(
     let p_id = Uuid::new_v4().to_string();
     let nationality = nationality.to_string();
 
-    // Reserve slots across the back line, midfield, and attack always start youth-aged
-    // so each club can open with real academy prospects instead of an empty youth squad.
-    let age = if matches!(index, 8 | 15 | 21) {
+    // Reserve one slot per position group (GK + back line + midfield + attack) as
+    // youth-aged so scouted youth recruits land at a consistent age across positions
+    // and clubs can open with real academy prospects instead of an empty youth squad.
+    let age = if matches!(index, 1 | 8 | 15 | 21) {
         rng.random_range(17..22)
     } else {
         rng.random_range(17..36)

--- a/src-tauri/crates/ofm_core/src/generator/mod.rs
+++ b/src-tauri/crates/ofm_core/src/generator/mod.rs
@@ -207,10 +207,11 @@ pub fn generate_youth_academy_recruit_with_nationality(
         .map(generation::canonicalize_generated_nationality)
         .unwrap_or_else(|| pick_nationality_from_def(&team.country, &country_codes, &mut rng));
     let youth_slots: &[usize] = match target_position.map(Position::to_group_position) {
+        Some(Position::Goalkeeper) => &[1],
         Some(Position::Defender) => &[8],
         Some(Position::Midfielder) => &[15],
         Some(Position::Forward) => &[21],
-        _ => &[8, 15, 21],
+        _ => &[1, 8, 15, 21],
     };
     let slot_index = youth_slots[rng.random_range(0..youth_slots.len())];
     let mut player =
@@ -231,6 +232,7 @@ pub fn generate_national_team_player(nationality: &str, squad_slot: usize) -> Pl
     let nationality = generation::canonicalize_generated_nationality(nationality);
     // Avoid the youth-reserved slots so the player generates at a senior age.
     let slot = match squad_slot % 22 {
+        1 => 0,
         8 => 7,
         15 => 14,
         21 => 20,
@@ -1365,6 +1367,37 @@ mod tests {
 
         assert_eq!(player.nationality, "ENG");
         assert_eq!(player.football_nation, "ENG");
+    }
+
+    #[test]
+    fn test_youth_recruit_targets_goalkeeper() {
+        let team = domain::team::Team::new(
+            "team-1".to_string(),
+            "London FC".to_string(),
+            "LON".to_string(),
+            "England".to_string(),
+            "London".to_string(),
+            "Ground".to_string(),
+            20000,
+        );
+
+        for _ in 0..16 {
+            let player = generate_youth_academy_recruit_with_nationality(
+                &team,
+                Some(&Position::Goalkeeper),
+                None,
+            );
+            assert_eq!(
+                player.position,
+                Position::Goalkeeper,
+                "targeted youth recruit must be a goalkeeper",
+            );
+            assert!(
+                opening_player_age(&player.date_of_birth)
+                    .is_some_and(|age| age <= OPENING_YOUTH_MAX_AGE),
+                "targeted youth recruit must be youth-aged",
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/crates/ofm_core/src/scouting.rs
+++ b/src-tauri/crates/ofm_core/src/scouting.rs
@@ -704,6 +704,7 @@ fn objective_i18n_key(objective: YouthScoutingObjective) -> &'static str {
 
 fn youth_target_position_i18n_key(position: &Position) -> &'static str {
     match position {
+        Position::Goalkeeper => "common.positions.Goalkeeper",
         Position::Defender => "common.positions.Defender",
         Position::Midfielder => "common.positions.Midfielder",
         Position::Forward => "common.positions.Forward",

--- a/src-tauri/src/commands/transfers.rs
+++ b/src-tauri/src/commands/transfers.rs
@@ -488,6 +488,7 @@ fn parse_youth_objective(value: Option<&str>) -> Result<YouthScoutingObjective, 
 fn parse_youth_target_position(value: Option<&str>) -> Result<Option<Position>, String> {
     match value {
         None | Some("") => Ok(None),
+        Some("Goalkeeper") => Ok(Some(Position::Goalkeeper)),
         Some("Defender") => Ok(Some(Position::Defender)),
         Some("Midfielder") => Ok(Some(Position::Midfielder)),
         Some("Forward") => Ok(Some(Position::Forward)),
@@ -1151,11 +1152,18 @@ mod tests {
 
     #[test]
     fn parse_youth_target_position_returns_backend_key_when_value_is_unsupported() {
-        let result = super::parse_youth_target_position(Some("Goalkeeper"));
+        let result = super::parse_youth_target_position(Some("Sweeper"));
 
         assert_eq!(
             result.unwrap_err(),
             super::INVALID_YOUTH_SCOUTING_TARGET_POSITION_ERROR
         );
+    }
+
+    #[test]
+    fn parse_youth_target_position_accepts_goalkeeper() {
+        let result = super::parse_youth_target_position(Some("Goalkeeper"));
+
+        assert_eq!(result.unwrap(), Some(Position::Goalkeeper));
     }
 }

--- a/src/components/scouting/ScoutingYouthRecruitmentCard.test.tsx
+++ b/src/components/scouting/ScoutingYouthRecruitmentCard.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { StaffData, YouthScoutingAssignment } from "../../store/gameStore";
+import ScoutingYouthRecruitmentCard from "./ScoutingYouthRecruitmentCard";
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key: string, params?: Record<string, string | number>) => {
+            if (key === "common.positions.Goalkeeper") return "Goalkeeper";
+            if (key === "common.positions.Defender") return "Defender";
+            if (key === "common.positions.Midfielder") return "Midfielder";
+            if (key === "common.positions.Forward") return "Forward";
+            if (key === "scouting.youthAnyPosition") return "Any position";
+            if (key === "scouting.activeYouthSearches") {
+                return `Active: ${params?.count ?? 0}`;
+            }
+            return key;
+        },
+        i18n: { language: "en" },
+    }),
+}));
+
+function createScout(overrides: Partial<StaffData> = {}): StaffData {
+    return {
+        id: "scout-1",
+        first_name: "Sam",
+        last_name: "Scout",
+        date_of_birth: "1985-01-01",
+        nationality: "GB",
+        role: "Scout",
+        attributes: {
+            coaching: 20,
+            judgingAbility: 65,
+            judgingPotential: 70,
+            physiotherapy: 10,
+        },
+        team_id: "team-1",
+        specialization: null,
+        wage: 0,
+        contract_end: null,
+        ...overrides,
+    };
+}
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof ScoutingYouthRecruitmentCard>> = {}) {
+    const defaults: React.ComponentProps<typeof ScoutingYouthRecruitmentCard> = {
+        youthAssignments: [] as YouthScoutingAssignment[],
+        scouts: [createScout()],
+        availableScouts: [createScout()],
+        isStarting: false,
+        selectedScoutId: "scout-1",
+        region: "Domestic",
+        objective: "Balanced",
+        targetPosition: "",
+        onScoutChange: () => {},
+        onRegionChange: () => {},
+        onObjectiveChange: () => {},
+        onTargetPositionChange: () => {},
+        onStartSearch: () => {},
+        onCancelSearch: () => {},
+        onReassignSearch: () => {},
+    };
+    return render(<ScoutingYouthRecruitmentCard {...defaults} {...overrides} />);
+}
+
+describe("ScoutingYouthRecruitmentCard target-position dropdown", () => {
+    it("offers Goalkeeper as a target position", () => {
+        renderCard();
+
+        fireEvent.click(screen.getByRole("combobox", { name: "scouting.youthTargetLabel" }));
+
+        expect(screen.getByRole("option", { name: "Goalkeeper" })).toBeInTheDocument();
+    });
+});

--- a/src/components/scouting/ScoutingYouthRecruitmentCard.tsx
+++ b/src/components/scouting/ScoutingYouthRecruitmentCard.tsx
@@ -153,6 +153,7 @@ export default function ScoutingYouthRecruitmentCard({
                             onChange={(event) => onTargetPositionChange(event.target.value)}
                         >
                             <option value="">{t("scouting.youthAnyPosition")}</option>
+                            <option value="Goalkeeper">{t("common.positions.Goalkeeper")}</option>
                             <option value="Defender">{t("common.positions.Defender")}</option>
                             <option value="Midfielder">{t("common.positions.Midfielder")}</option>
                             <option value="Forward">{t("common.positions.Forward")}</option>


### PR DESCRIPTION
The youth recruitment target dropdown didn't offer Goalkeeper, and even if it had, the generator only sampled outfield youth-reserved slots (8/15/21) so a targeted GK recruit would never come back as one. Add Goalkeeper to the dropdown, route it through the i18n key map, and reserve slot 1 as a GK youth-aged slot (with national-team generation updated to skip it so senior keepers stay senior-aged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Youth recruitment now supports selecting **Goalkeeper** as a target position, including in scouting UI labels and dropdown options.

* **Bug Fixes**
  * Improved youth recruit/player generation to better respect reserved youth slots, including goalkeeper-related handling and more consistent youth recruitment age behavior.

* **Tests**
  * Added/updated unit tests to verify goalkeeper targeting is accepted end-to-end and youth recruit generation meets age/position expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->