### PR TITLE
fix(squad): stop silently deleting players on jersey-number collisions

### DIFF
--- a/src-tauri/crates/db/src/repositories/player_repo.rs
+++ b/src-tauri/crates/db/src/repositories/player_repo.rs
@@ -41,14 +41,52 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
     let training_focus_str: Option<String> = p.training_focus.as_ref().map(|f| format!("{:?}", f));
 
     conn.execute(
-        "INSERT OR REPLACE INTO players
+        "INSERT INTO players
          (id, match_name, full_name, date_of_birth, nationality, football_nation, birth_country, position,
           attributes, condition, morale, injury, team_id, retired, traits,
           contract_end, wage, market_value, stats, career,
           transfer_listed, loan_listed, transfer_offers, alternate_positions,
           natural_position, training_focus, morale_core, footedness, weak_foot, fitness, squad_role,
           ovr, potential, media_json, jersey_number, loan_offers, active_loan, movement_history)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36, ?37, ?38)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36, ?37, ?38)
+         ON CONFLICT(id) DO UPDATE SET
+           match_name = excluded.match_name,
+           full_name = excluded.full_name,
+           date_of_birth = excluded.date_of_birth,
+           nationality = excluded.nationality,
+           football_nation = excluded.football_nation,
+           birth_country = excluded.birth_country,
+           position = excluded.position,
+           attributes = excluded.attributes,
+           condition = excluded.condition,
+           morale = excluded.morale,
+           injury = excluded.injury,
+           team_id = excluded.team_id,
+           retired = excluded.retired,
+           traits = excluded.traits,
+           contract_end = excluded.contract_end,
+           wage = excluded.wage,
+           market_value = excluded.market_value,
+           stats = excluded.stats,
+           career = excluded.career,
+           transfer_listed = excluded.transfer_listed,
+           loan_listed = excluded.loan_listed,
+           transfer_offers = excluded.transfer_offers,
+           alternate_positions = excluded.alternate_positions,
+           natural_position = excluded.natural_position,
+           training_focus = excluded.training_focus,
+           morale_core = excluded.morale_core,
+           footedness = excluded.footedness,
+           weak_foot = excluded.weak_foot,
+           fitness = excluded.fitness,
+           squad_role = excluded.squad_role,
+           ovr = excluded.ovr,
+           potential = excluded.potential,
+           media_json = excluded.media_json,
+           jersey_number = excluded.jersey_number,
+           loan_offers = excluded.loan_offers,
+           active_loan = excluded.active_loan,
+           movement_history = excluded.movement_history",
         params![
             p.id,
             p.match_name,
@@ -583,6 +621,36 @@ mod tests {
         upsert_players(db.conn(), &players).unwrap();
         let all = load_all_players(db.conn()).unwrap();
         assert_eq!(all.len(), 3);
+    }
+
+    // Reproduces the squad-eating bug: when a player arrives at a team and is
+    // assigned a jersey number that's already taken, the previous holder must
+    // not silently disappear. Persistence should refuse the second write loudly,
+    // not delete the first row to make room.
+    #[test]
+    fn test_assigning_taken_jersey_must_not_delete_previous_holder() {
+        let db = test_db();
+
+        let mut original = sample_player("p-original", Some("team-dortmund"));
+        original.jersey_number = Some(6);
+        upsert_player(db.conn(), &original).unwrap();
+
+        let mut newcomer = sample_player("p-newcomer", Some("team-dortmund"));
+        newcomer.jersey_number = Some(6);
+        let result = upsert_player(db.conn(), &newcomer);
+
+        assert!(
+            result.is_err(),
+            "second save into an occupied (team, jersey) slot must fail loudly"
+        );
+
+        let all = load_all_players(db.conn()).unwrap();
+        let ids: std::collections::HashSet<&str> =
+            all.iter().map(|player| player.id.as_str()).collect();
+        assert!(
+            ids.contains("p-original"),
+            "original #6 wearer must still exist in the DB"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/db/src/repositories/player_repo.rs
+++ b/src-tauri/crates/db/src/repositories/player_repo.rs
@@ -422,6 +422,54 @@ mod tests {
         assert_eq!(all[0].birth_country, None);
     }
 
+    // Pins the contract of the `INSERT ... ON CONFLICT(id) DO UPDATE SET ...`
+    // upsert: every column listed in the SET clause must actually overwrite
+    // the previously stored value on a second save with the same id. If a
+    // future field is added to `Player` and the SET clause is not updated to
+    // match, this test starts failing because the stored row keeps stale data
+    // on subsequent saves.
+    #[test]
+    fn test_upsert_player_with_same_id_overwrites_all_fields() {
+        let db = test_db();
+        let mut player = sample_player("p-mutating", Some("team-1"));
+        player.jersey_number = Some(10);
+        player.condition = 80;
+        player.morale = 70;
+        upsert_player(db.conn(), &player).unwrap();
+
+        player.team_id = Some("team-2".to_string());
+        player.jersey_number = Some(7);
+        player.condition = 50;
+        player.morale = 40;
+        player.wage = 12_000;
+        player.market_value = 1_200_000;
+        player.transfer_listed = true;
+        player.loan_listed = true;
+        player.position = Position::Striker;
+        player.natural_position = Position::Forward;
+        player.ovr = 88;
+        player.potential = 95;
+        player.contract_end = Some("2030-06-30".to_string());
+        upsert_player(db.conn(), &player).unwrap();
+
+        let all = load_all_players(db.conn()).unwrap();
+        assert_eq!(all.len(), 1, "same id must update in place, not duplicate");
+        let stored = &all[0];
+        assert_eq!(stored.team_id.as_deref(), Some("team-2"));
+        assert_eq!(stored.jersey_number, Some(7));
+        assert_eq!(stored.condition, 50);
+        assert_eq!(stored.morale, 40);
+        assert_eq!(stored.wage, 12_000);
+        assert_eq!(stored.market_value, 1_200_000);
+        assert!(stored.transfer_listed);
+        assert!(stored.loan_listed);
+        assert_eq!(stored.position, Position::Striker);
+        assert_eq!(stored.natural_position, Position::Forward);
+        assert_eq!(stored.ovr, 88);
+        assert_eq!(stored.potential, 95);
+        assert_eq!(stored.contract_end.as_deref(), Some("2030-06-30"));
+    }
+
     #[test]
     fn test_player_football_identity_roundtrip() {
         let db = test_db();

--- a/src-tauri/crates/ofm_core/src/contracts.rs
+++ b/src-tauri/crates/ofm_core/src/contracts.rs
@@ -673,8 +673,12 @@ pub fn offer_free_agent_contract(
             .checked_add_months(Months::new(offer.contract_years * 12))
             .ok_or(ERR_UNABLE_TO_CALCULATE_CONTRACT_END_DATE.to_string())?;
 
+        let resolved_jersey_number =
+            crate::roster::resolve_jersey_for(game, &game.players[player_index], &team);
+
         let player = &mut game.players[player_index];
         player.team_id = Some(team.id.clone());
+        player.jersey_number = resolved_jersey_number;
         player.wage = offer.weekly_wage;
         player.contract_end = Some(new_contract_end.format("%Y-%m-%d").to_string());
         player.transfer_listed = false;

--- a/src-tauri/crates/ofm_core/src/lib.rs
+++ b/src-tauri/crates/ofm_core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod player_rating;
 pub mod promotion;
 pub mod random_events;
 pub mod reputation;
+pub mod roster;
 pub mod schedule;
 pub mod scouting;
 pub mod season_awards;

--- a/src-tauri/crates/ofm_core/src/roster.rs
+++ b/src-tauri/crates/ofm_core/src/roster.rs
@@ -1,0 +1,171 @@
+//! Roster invariants shared across the engine's join-a-team paths.
+//!
+//! The persistence layer enforces "no two players at one club share a jersey
+//! number" via a unique index, but enforcement at save time only catches
+//! violations *after* the in-memory state has already produced one. This
+//! module is the single choke point that prevents such states from arising.
+
+use crate::game::Game;
+use domain::player::Player;
+use domain::team::Team;
+
+/// Decide which jersey number `player` should wear at `team`.
+///
+/// * If the player's current jersey is free at `team`, returns it (no churn).
+/// * Otherwise picks the lowest available number in `1..=99` at the destination.
+/// * Returns `None` only when all 99 slots at the destination are already
+///   taken — unreachable for any realistic squad size, but the caller should
+///   still handle it.
+///
+/// Pure: does not mutate anything. The caller writes the returned value into
+/// `player.jersey_number` as part of whichever team-change side-effect it is
+/// already performing.
+///
+/// The player about to be moved is excluded from the destination's occupied
+/// set by id, so the function is safe to call even when the player happens
+/// to already be at `team` (e.g. an idempotent reassignment).
+pub fn resolve_jersey_for(game: &Game, player: &Player, team: &Team) -> Option<u8> {
+    let occupied: std::collections::HashSet<u8> = game
+        .players
+        .iter()
+        .filter(|other| {
+            other.id != player.id && other.team_id.as_deref() == Some(team.id.as_str())
+        })
+        .filter_map(|other| other.jersey_number)
+        .collect();
+    match player.jersey_number {
+        Some(current) if !occupied.contains(&current) => Some(current),
+        _ => (1u8..=99).find(|number| !occupied.contains(number)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::GameClock;
+    use chrono::{TimeZone, Utc};
+    use domain::manager::Manager;
+    use domain::player::{Player, PlayerAttributes, Position};
+    use domain::team::Team;
+
+    fn default_attrs() -> PlayerAttributes {
+        PlayerAttributes {
+            pace: 60, stamina: 60, strength: 60, agility: 60,
+            passing: 60, shooting: 60, tackling: 60, dribbling: 60,
+            defending: 60, positioning: 60, vision: 60, decisions: 60,
+            composure: 60, aggression: 60, teamwork: 60, leadership: 60,
+            handling: 30, reflexes: 30, aerial: 60,
+        }
+    }
+
+    fn make_player(id: &str, team_id: Option<&str>, jersey: Option<u8>) -> Player {
+        let mut player = Player::new(
+            id.to_string(),
+            id.to_string(),
+            id.to_string(),
+            "2000-01-01".to_string(),
+            "England".to_string(),
+            Position::Forward,
+            default_attrs(),
+        );
+        player.team_id = team_id.map(|t| t.to_string());
+        player.jersey_number = jersey;
+        player
+    }
+
+    fn make_team(id: &str) -> Team {
+        Team::new(
+            id.to_string(),
+            id.to_string(),
+            id.to_string(),
+            "England".to_string(),
+            "City".to_string(),
+            "Ground".to_string(),
+            20_000,
+        )
+    }
+
+    fn make_game(players: Vec<Player>) -> Game {
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "m-1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "England".to_string(),
+        );
+        Game::new(clock, manager, vec![make_team("team-a")], players, vec![], vec![])
+    }
+
+    #[test]
+    fn keeps_preferred_jersey_when_free_at_destination() {
+        let moving = make_player("p-moving", None, Some(6));
+        let game = make_game(vec![make_player("p-existing", Some("team-a"), Some(10))]);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn reassigns_when_preferred_jersey_is_taken() {
+        let moving = make_player("p-moving", None, Some(6));
+        let game = make_game(vec![make_player("p-existing", Some("team-a"), Some(6))]);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn picks_lowest_free_when_player_has_no_preferred_jersey() {
+        let moving = make_player("p-moving", None, None);
+        let players = vec![
+            make_player("p-1", Some("team-a"), Some(1)),
+            make_player("p-2", Some("team-a"), Some(2)),
+            make_player("p-3", Some("team-a"), Some(4)),
+        ];
+        let game = make_game(players);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn excludes_moving_player_from_occupancy() {
+        // Moving player already at the destination wearing #6 — resolver must
+        // not see their own jersey as a conflict.
+        let moving = make_player("p-moving", Some("team-a"), Some(6));
+        let game = make_game(vec![moving.clone()]);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn ignores_players_at_other_teams_and_free_agents() {
+        let moving = make_player("p-moving", None, Some(6));
+        let players = vec![
+            make_player("p-other-team", Some("team-z"), Some(6)),
+            make_player("p-free-agent", None, Some(6)),
+        ];
+        let game = make_game(players);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_destination_is_full() {
+        let moving = make_player("p-moving", None, None);
+        let mut players = Vec::new();
+        for n in 1u8..=99 {
+            players.push(make_player(&format!("p-{}", n), Some("team-a"), Some(n)));
+        }
+        let game = make_game(players);
+        assert_eq!(
+            resolve_jersey_for(&game, &moving, &make_team("team-a")),
+            None
+        );
+    }
+}

--- a/src-tauri/crates/ofm_core/src/scouting.rs
+++ b/src-tauri/crates/ofm_core/src/scouting.rs
@@ -598,6 +598,7 @@ pub fn apply_youth_recruitment_response(
             }
             let player_id = signed_player.id.clone();
             let player_name = signed_player.full_name.clone();
+            let signed_jersey_number = signed_player.jersey_number;
             game.players.push(signed_player);
 
             let message = &mut game.messages[message_index];
@@ -609,6 +610,7 @@ pub fn apply_youth_recruitment_response(
             {
                 updated_prospect.team_id = game.manager.team_id.clone();
                 updated_prospect.squad_role = SquadRole::Youth;
+                updated_prospect.jersey_number = signed_jersey_number;
             }
             if let Some(action) = message.actions.get_mut(action_index) {
                 action.resolved = true;

--- a/src-tauri/crates/ofm_core/src/scouting.rs
+++ b/src-tauri/crates/ofm_core/src/scouting.rs
@@ -590,6 +590,12 @@ pub fn apply_youth_recruitment_response(
             let mut signed_player = prospect;
             signed_player.team_id = game.manager.team_id.clone();
             signed_player.squad_role = SquadRole::Youth;
+            if let Some(team_id) = signed_player.team_id.clone()
+                && let Some(team) = game.teams.iter().find(|team| team.id == team_id)
+            {
+                signed_player.jersey_number =
+                    crate::roster::resolve_jersey_for(game, &signed_player, team);
+            }
             let player_id = signed_player.id.clone();
             let player_name = signed_player.full_name.clone();
             game.players.push(signed_player);

--- a/src-tauri/crates/ofm_core/src/transfers.rs
+++ b/src-tauri/crates/ofm_core/src/transfers.rs
@@ -2449,6 +2449,12 @@ fn execute_loan(
     let parent_team_name = team_name_or_id(game, parent_team_id);
     let loan_team_name = team_name_or_id(game, loan_team_id);
 
+    let resolved_jersey_number = game
+        .teams
+        .iter()
+        .find(|team| team.id == loan_team_id)
+        .and_then(|team| crate::roster::resolve_jersey_for(game, &player_snapshot, team));
+
     for team in &mut game.teams {
         team.remove_player_references(player_id);
     }
@@ -2460,6 +2466,7 @@ fn execute_loan(
         .ok_or("be.error.playerNotFound")?;
 
     player.team_id = Some(loan_team_id.to_string());
+    player.jersey_number = resolved_jersey_number;
     player.transfer_listed = false;
     player.loan_listed = false;
     player.active_loan = Some(ActiveLoan {
@@ -3263,10 +3270,13 @@ pub fn process_loan_returns(game: &mut Game) {
             continue;
         }
 
-        let loan_snapshot = game
+        let player_snapshot = game
             .players
             .iter()
             .find(|player| player.id == player_id)
+            .cloned();
+        let loan_snapshot = player_snapshot
+            .as_ref()
             .and_then(|player| player.active_loan.clone());
         let movement_context = loan_snapshot.as_ref().map(|loan| {
             (
@@ -3277,6 +3287,14 @@ pub fn process_loan_returns(game: &mut Game) {
                 loan.end_date.clone(),
             )
         });
+        let resolved_jersey_number = match (&player_snapshot, &loan_snapshot) {
+            (Some(snap), Some(loan)) => game
+                .teams
+                .iter()
+                .find(|team| team.id == loan.parent_team_id)
+                .and_then(|team| crate::roster::resolve_jersey_for(game, snap, team)),
+            _ => None,
+        };
 
         for team in &mut game.teams {
             team.remove_player_references(&player_id);
@@ -3289,6 +3307,7 @@ pub fn process_loan_returns(game: &mut Game) {
             && let Some(loan) = player.active_loan.take()
         {
             player.team_id = Some(loan.parent_team_id);
+            player.jersey_number = resolved_jersey_number;
             player.loan_listed = false;
             if let Some((
                 loan_team_id,
@@ -3359,9 +3378,16 @@ fn execute_transfer(
         })
         .unwrap_or_default();
 
+    let resolved_jersey_number = game
+        .teams
+        .iter()
+        .find(|team| team.id == to_team_id)
+        .and_then(|team| crate::roster::resolve_jersey_for(game, &player_snapshot, team));
+
     // Move player
     if let Some(p) = game.players.iter_mut().find(|p| p.id == player_id) {
         p.team_id = Some(to_team_id.to_string());
+        p.jersey_number = resolved_jersey_number;
         p.transfer_listed = false;
         p.loan_listed = false;
         p.movement_history.push(PlayerMovementEntry {

--- a/src-tauri/crates/ofm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/transfers_tests.rs
@@ -2684,3 +2684,56 @@ fn completed_transfer_news_is_not_duplicated_when_article_already_exists() {
         1
     );
 }
+
+// A transfer must succeed end-to-end even when the incoming player's jersey
+// number is already worn by someone at the buying club. Both players must
+// remain in the game and end up with distinct jerseys at the new club.
+#[test]
+fn transfer_succeeds_when_incoming_player_jersey_collides_with_buyer_squad() {
+    // Player being transferred (currently at the selling club, wears #6 there).
+    let mut incoming = make_player("incoming-six");
+    incoming.jersey_number = Some(6);
+    incoming.contract_end = Some("2028-06-30".to_string());
+    incoming.market_value = 1_000_000;
+
+    let mut game = make_game_with_player(incoming, vec![], 5_000_000, 2_000_000);
+
+    // An existing squad member at the buying club, also wearing #6.
+    let mut existing = make_user_player("existing-six");
+    existing.jersey_number = Some(6);
+    game.players.push(existing);
+
+    let result = make_transfer_bid(&mut game, "incoming-six", 1_500_000)
+        .expect("bid for an affordable player should be accepted");
+    assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+
+    // If the bid is registered immediately, the transfer is already complete;
+    // otherwise process the scheduled registration to finalize the move.
+    process_pending_transfer_registrations(&mut game);
+
+    let existing_after = game
+        .players
+        .iter()
+        .find(|player| player.id == "existing-six")
+        .expect("existing #6 must not be silently dropped by the transfer");
+    let incoming_after = game
+        .players
+        .iter()
+        .find(|player| player.id == "incoming-six")
+        .expect("incoming player must be present after transfer");
+
+    assert_eq!(
+        incoming_after.team_id.as_deref(),
+        Some("team-1"),
+        "incoming player must end up at the buying club"
+    );
+    assert_eq!(
+        existing_after.team_id.as_deref(),
+        Some("team-1"),
+        "existing player must stay at the buying club"
+    );
+    assert_ne!(
+        existing_after.jersey_number, incoming_after.jersey_number,
+        "two players at the same club must have different jersey numbers"
+    );
+}

--- a/src-tauri/crates/ofm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/transfers_tests.rs
@@ -2732,8 +2732,14 @@ fn transfer_succeeds_when_incoming_player_jersey_collides_with_buyer_squad() {
         Some("team-1"),
         "existing player must stay at the buying club"
     );
-    assert_ne!(
-        existing_after.jersey_number, incoming_after.jersey_number,
-        "two players at the same club must have different jersey numbers"
+    assert_eq!(
+        existing_after.jersey_number,
+        Some(6),
+        "existing player must keep their #6 — the resolver must not churn settled assignments"
+    );
+    assert_eq!(
+        incoming_after.jersey_number,
+        Some(1),
+        "incoming player whose #6 is taken must get the lowest free number (#1)"
     );
 }


### PR DESCRIPTION
The save was losing players whenever an incoming transfer, loan or signing happened to wear a jersey number already taken at the new club. Two layered fixes for the same root cause.

Persistence (db/repositories/player_repo): switch upsert_player from `INSERT OR REPLACE` to `INSERT ... ON CONFLICT(id) DO UPDATE SET ...`. The previous form resolved any unique-constraint conflict by deleting the conflicting row first, so a collision on idx_players_team_jersey silently dropped the existing holder. The new form only handles primary-key conflicts; secondary unique conflicts surface as a loud error instead of data loss.

Engine (ofm_core/roster): new resolve_jersey_for(game, player, team) helper, the single point where "no two players at a team share a jersey" is enforced for the engine. Keeps the player's current number when it's free at the destination, otherwise picks the lowest free slot in 1..=99. Wired into every join site that mutates team_id: execute_transfer, execute_loan, process_loan_returns, offer_free_agent_contract, apply_youth_recruitment_response (youth sign path).

Tests pinning both halves of the bug:
- player_repo: a second upsert into an occupied (team, jersey) slot now errors instead of silently removing the previous holder.
- transfers: a transfer where the incoming player's number is already worn at the buyer leaves both players with distinct jerseys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved jersey-number assignment across permanent transfers, loan moves/returns, free-agent signing, and youth prospect signing—keeps the preferred jersey when available, otherwise selects the lowest open option.
  * Prevented jersey collisions from deleting or overwriting the existing player record; conflicts are now handled safely without removing the previous holder.
* **Tests**
  * Added regression coverage for same-id persistence overwrites and for jersey-collision scenarios during accepted transfer bids and contract acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->