### PR TITLE
feat(db): optional pre-write .db snapshot for save debugging

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,10 @@ opt-level = 3
 
 [features]
 mcp = ["dep:rmcp", "dep:axum", "dep:tower", "dep:tokio", "dep:tokio-util"]
+# Forwards to `db/save-snapshots`. Enable with `tauri dev -f save-snapshots`
+# (or via the `ofm-dev-snap` alias from shell.nix) to write a date-stamped
+# copy of each save's `.db` before every overwrite. Dev-only.
+save-snapshots = ["db/save-snapshots"]
 
 [dependencies.rmcp]
 version = "1.7"

--- a/src-tauri/crates/db/Cargo.toml
+++ b/src-tauri/crates/db/Cargo.toml
@@ -3,6 +3,15 @@ name = "db"
 version = "0.3.0"
 edition = "2024"
 
+[features]
+default = []
+# Dev-only: snapshot each save's `.db` file before every overwrite into a
+# date-stamped sibling (`<uuid>.db.snap-YYYYMMDD-HHMMSS.fff`). The 20 most
+# recent snapshots per save are kept; older ones are pruned automatically.
+# Costs roughly one `.db`-sized copy per save, so plan for ~1 GB of disk per
+# save you're debugging.
+save-snapshots = []
+
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 domain = { version = "0.3.0", path = "../domain" }

--- a/src-tauri/crates/db/src/save_manager.rs
+++ b/src-tauri/crates/db/src/save_manager.rs
@@ -44,6 +44,81 @@ fn save_not_found_error(save_id: &str) -> String {
     backend_error_with_param("be.error.saveNotFound", "saveId", save_id)
 }
 
+/// Number of `.db.snap-*` files to keep next to each save when the
+/// `save-snapshots` Cargo feature is enabled. Older snapshots are pruned
+/// automatically.
+#[cfg(feature = "save-snapshots")]
+const MAX_SNAPSHOTS_PER_SAVE: usize = 20;
+
+/// Copy `db_path` to a date-stamped sibling before the file is overwritten,
+/// then prune older snapshots so at most `MAX_SNAPSHOTS_PER_SAVE` survive.
+///
+/// Only compiled when the `save-snapshots` Cargo feature is on. Without it
+/// this is a zero-cost no-op (the `_db_path` arg is ignored).
+#[cfg(feature = "save-snapshots")]
+fn snapshot_db_before_write(db_path: &Path) -> Result<(), String> {
+    if !db_path.exists() {
+        return Ok(());
+    }
+    let stamp = Utc::now().format("%Y%m%d-%H%M%S%.3f").to_string();
+    let file_name = db_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "save-snapshot: invalid db filename".to_string())?;
+    let snap_name = format!("{}.snap-{}", file_name, stamp);
+    let snap_path = db_path.with_file_name(&snap_name);
+    fs::copy(db_path, &snap_path)
+        .map_err(|err| format!("save-snapshot: copy failed: {err}"))?;
+    info!(
+        "[save_manager] snapshot {} -> {}",
+        db_path.display(),
+        snap_path.display()
+    );
+    prune_old_snapshots(db_path, MAX_SNAPSHOTS_PER_SAVE);
+    Ok(())
+}
+
+#[cfg(not(feature = "save-snapshots"))]
+fn snapshot_db_before_write(_db_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+/// Drop the oldest `.db.snap-*` siblings of `db_path` until at most `keep`
+/// remain. Errors are swallowed (best-effort cleanup) — losing the prune is
+/// far less bad than failing a save.
+#[cfg(feature = "save-snapshots")]
+fn prune_old_snapshots(db_path: &Path, keep: usize) {
+    let Some(parent) = db_path.parent() else {
+        return;
+    };
+    let Some(file_name) = db_path.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let prefix = format!("{}.snap-", file_name);
+
+    let Ok(entries) = fs::read_dir(parent) else {
+        return;
+    };
+    let mut snapshots: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(&prefix))
+        })
+        .collect();
+    // Names share a fixed prefix and end with a sortable timestamp, so
+    // lexicographic order matches chronological order.
+    snapshots.sort();
+    while snapshots.len() > keep {
+        if let Some(oldest) = snapshots.first() {
+            let _ = fs::remove_file(oldest);
+        }
+        snapshots.remove(0);
+    }
+}
+
 impl SaveManager {
     /// Initialize the SaveManager without blocking startup on a missing save index.
     pub fn init(saves_dir: &Path) -> Result<Self, String> {
@@ -230,6 +305,7 @@ impl SaveManager {
 
         canonicalize_game_starting_xi_ids(&mut persisted_game);
 
+        snapshot_db_before_write(&db_path)?;
         let db = GameDatabase::open(&db_path)?;
         GamePersistenceWriter::write_game(&db, &persisted_game, save_id, &save_name)?;
         drop(db);
@@ -261,6 +337,7 @@ impl SaveManager {
             .clone();
 
         let db_path = self.saves_dir.join(&entry.db_filename);
+        snapshot_db_before_write(&db_path)?;
         let db = GameDatabase::open(&db_path)?;
         GamePersistenceWriter::write_stats_state(&db, stats)?;
         drop(db);
@@ -302,6 +379,8 @@ impl SaveManager {
         let mut persisted_game = game.clone();
         canonicalize_game_starting_xi_ids(&mut persisted_game);
         let clone_ms = clone_timer.elapsed().as_millis();
+
+        snapshot_db_before_write(&db_path)?;
 
         let db_open_timer = Instant::now();
         let db = GameDatabase::open(&db_path)?;

--- a/src-tauri/crates/db/src/save_manager.rs
+++ b/src-tauri/crates/db/src/save_manager.rs
@@ -566,6 +566,7 @@ impl SaveManager {
         drop(db);
 
         if needs_resave {
+            snapshot_db_before_write(&db_path)?;
             let db = GameDatabase::open(&db_path)?;
             GamePersistenceWriter::write_game(&db, &game, save_id, &save_name)?;
             drop(db);


### PR DESCRIPTION
Adds a `save-snapshots` Cargo feature that, when enabled, copies each save's `.db` to a date-stamped sibling
(`<uuid>.db.snap-YYYYMMDD-HHMMSS.fff`) before every overwrite. The 20 most recent snapshots per save are kept; older ones are pruned automatically. With the feature off (the default) the snapshot code is `#[cfg(not(feature = ...))]`-gated to a no-op, so production builds carry no runtime overhead.

Intent: short-circuit "when did this player / row vanish?" debugging. With a snapshot per save event, we can bisect a corruption across the turn-by-turn timeline without having to reproduce from scratch.

Wired into the three overwrite paths in `save_manager`:
- save_game
- save_stats_state
- save_game_with_stats Not added to create_save_with_stats (new save, no prior state).

Top-level Tauri crate forwards the feature
(`save-snapshots = ["db/save-snapshots"]`). Enable with `cargo tauri dev -f save-snapshots` (or via a local shell alias). Disk cost when enabled: ~one `.db`-sized copy per save (≈50 MB), 20 kept, so worst case ≈1 GB per save being debugged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional dev-only snapshot mode that creates dated backup copies of save database files before they are overwritten or upgraded.
  * Backups are automatically managed by keeping only a limited number of the most recent snapshots per save and pruning older ones.
  * Can be enabled during development via the new feature flag (for example, using `tauri dev -f save-snapshots`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->