### PR TITLE
Fix transfer flows

### DIFF
--- a/src-tauri/crates/ofm_core/src/end_of_season.rs
+++ b/src-tauri/crates/ofm_core/src/end_of_season.rs
@@ -934,6 +934,14 @@ pub fn process_end_of_season(game: &mut Game) -> EndOfSeasonSummary {
                         kind: FinancialTransactionKind::PrizeMoney,
                     });
                 }
+
+                // Refresh the transfer envelope for the new season. Formula
+                // matches worldgen (generator/mod.rs:543): 15% of finance.
+                // Since `execute_transfer` debits the budget on every buy and
+                // no other path adds to it, without this refill the market
+                // would freeze after 2-3 seasons as every club drained to
+                // zero.
+                team.transfer_budget = (team.finance as f64 * 0.15) as i64;
             }
         }
 

--- a/src-tauri/crates/ofm_core/src/end_of_season.rs
+++ b/src-tauri/crates/ofm_core/src/end_of_season.rs
@@ -941,7 +941,13 @@ pub fn process_end_of_season(game: &mut Game) -> EndOfSeasonSummary {
                 // no other path adds to it, without this refill the market
                 // would freeze after 2-3 seasons as every club drained to
                 // zero.
-                team.transfer_budget = (team.finance as f64 * 0.15) as i64;
+                // Clamp at zero — unlike worldgen (which only ever sees fresh
+                // positive finance), end-of-season runs on live state where a
+                // heavily indebted club can have negative `finance`. A
+                // negative envelope would still be rejected by
+                // `make_transfer_bid`, but showing "€-1.2M transfer budget"
+                // in the UI reads worse than a hard zero.
+                team.transfer_budget = ((team.finance as f64 * 0.15) as i64).max(0);
             }
         }
 

--- a/src-tauri/crates/ofm_core/src/transfers.rs
+++ b/src-tauri/crates/ofm_core/src/transfers.rs
@@ -3416,6 +3416,11 @@ fn execute_transfer(
     // Debit buying team
     if let Some(t) = game.teams.iter_mut().find(|t| t.id == to_team_id) {
         t.finance -= fee as i64;
+        // Also debit the transfer budget so the cumulative envelope shrinks
+        // as bids complete. `end_of_season` refills the envelope from finance
+        // at the next season rollover; without this line the budget only ever
+        // gated the *first* purchase and was silently uncapped thereafter.
+        t.transfer_budget -= fee as i64;
         // Remove from starting XI if player was there
         if let Some(pos) = t.starting_xi_ids.iter().position(|id| id == player_id) {
             t.starting_xi_ids.remove(pos);

--- a/src-tauri/crates/ofm_core/tests/end_of_season_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/end_of_season_tests.rs
@@ -2409,3 +2409,31 @@ fn retiree_scout_judging_attributes_derived_from_player_attrs() {
     // positioning=72, teamwork=68 → judging_potential = (72+68)/2 = 70
     assert_eq!(scout.attributes.judging_potential, 70);
 }
+
+#[test]
+fn process_end_of_season_refreshes_transfer_budget_from_finance() {
+    let mut game = make_completed_season_game();
+    // Simulate a season where the user emptied their transfer envelope and
+    // another club still has an unspent chunk. Both should be reset to a
+    // fresh envelope sized to post-prize finance — the "unspent chunk" is
+    // deliberately blown away to match the real-football convention of a
+    // new board grant each season.
+    let team1_idx = game.teams.iter().position(|t| t.id == "team1").unwrap();
+    game.teams[team1_idx].finance = 10_000_000;
+    game.teams[team1_idx].transfer_budget = 0;
+    let team2_idx = game.teams.iter().position(|t| t.id == "team2").unwrap();
+    game.teams[team2_idx].finance = 2_000_000;
+    game.teams[team2_idx].transfer_budget = 750_000;
+
+    process_end_of_season(&mut game);
+
+    // Formula matches worldgen (generator/mod.rs:543): 15% of finance.
+    // We assert the invariant against post-prize finance so the test stays
+    // valid regardless of how much prize money each team receives.
+    let team1 = game.teams.iter().find(|t| t.id == "team1").unwrap();
+    let team2 = game.teams.iter().find(|t| t.id == "team2").unwrap();
+    assert_eq!(team1.transfer_budget, (team1.finance as f64 * 0.15) as i64);
+    assert_eq!(team2.transfer_budget, (team2.finance as f64 * 0.15) as i64);
+    // Team1 went in with an empty envelope; the refill must have run.
+    assert!(team1.transfer_budget > 0);
+}

--- a/src-tauri/crates/ofm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/transfers_tests.rs
@@ -2743,3 +2743,31 @@ fn transfer_succeeds_when_incoming_player_jersey_collides_with_buyer_squad() {
         "incoming player whose #6 is taken must get the lowest free number (#1)"
     );
 }
+
+#[test]
+fn executed_transfer_debits_the_buying_team_transfer_budget() {
+    let mut player = make_player("player-budget-debit");
+    player.morale = 35;
+    player.stats.appearances = 1;
+    let starting_finance = 5_000_000;
+    let starting_budget = 2_000_000;
+    let mut game = make_game_with_player(player, vec![], starting_finance, starting_budget);
+    game.teams[0].reputation = 700;
+    game.teams[1].reputation = 350;
+
+    // First bid returns a counter — engine picks a suggestion around 950k.
+    make_transfer_bid(&mut game, "player-budget-debit", 900_000)
+        .expect("first bid should return a counter");
+    // Accepting the suggestion executes the transfer.
+    let result = make_transfer_bid(&mut game, "player-budget-debit", 950_000)
+        .expect("second bid should be accepted");
+    assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+
+    // Both `finance` and `transfer_budget` must drop by the executed fee.
+    // Regression guard for the pre-fix bug where `transfer_budget` gated
+    // only the first bid and stayed constant thereafter, letting a team
+    // spend €100M in €15M chunks against a €15M budget.
+    let buyer = game.teams.iter().find(|t| t.id == "team-1").unwrap();
+    assert_eq!(buyer.finance, starting_finance - 950_000);
+    assert_eq!(buyer.transfer_budget, starting_budget - 950_000);
+}

--- a/src/components/transfers/TransfersTab.test.tsx
+++ b/src/components/transfers/TransfersTab.test.tsx
@@ -988,8 +988,10 @@ describe("TransfersTab", function (): void {
 
     // Modal must stay open on acceptance so the user can read the
     // confirmation. Any auto-close reintroduces the 2-second flicker
-    // and the double-unmount of the deal workspace parent.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // and the double-unmount of the deal workspace parent. Wait past
+    // the old 2s timer so a regression that reintroduces it fires
+    // before this assertion runs.
+    await new Promise((resolve) => setTimeout(resolve, 2100));
     expect(
       screen.getByRole("dialog", { name: /john smith/i }),
     ).toBeInTheDocument();

--- a/src/components/transfers/TransfersTab.test.tsx
+++ b/src/components/transfers/TransfersTab.test.tsx
@@ -1,5 +1,4 @@
 import {
-  act,
   fireEvent,
   render,
   screen,
@@ -899,7 +898,7 @@ describe("TransfersTab", function (): void {
     });
   });
 
-  it("closes the deal workspace after an accepted transfer bid settles", async function (): Promise<void> {
+  it("keeps the bid modal and deal workspace open after acceptance so the user can review the result", async function (): Promise<void> {
     const state = createGameState([
       createPlayer({
         id: "player-market-1",
@@ -959,47 +958,48 @@ describe("TransfersTab", function (): void {
       return {};
     });
 
-    try {
-      render(
-        <TransfersTab
-          gameState={state}
-          onSelectPlayer={vi.fn()}
-          onSelectTeam={vi.fn()}
-          onGameUpdate={vi.fn()}
-        />,
-      );
+    render(
+      <TransfersTab
+        gameState={state}
+        onSelectPlayer={vi.fn()}
+        onSelectTeam={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
 
-      fireEvent.click(screen.getByRole("button", { name: /^bid$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^bid$/i }));
+    expect(
+      screen.getByRole("dialog", { name: /john smith/i }),
+    ).toBeInTheDocument();
+
+    await waitFor(function (): void {
       expect(
-        screen.getByRole("dialog", { name: /john smith/i }),
-      ).toBeInTheDocument();
+        screen.getByRole("button", { name: /submit bid/i }),
+      ).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /submit bid/i }));
 
-      await waitFor(function (): void {
-        expect(
-          screen.getByRole("button", { name: /submit bid/i }),
-        ).toBeEnabled();
-      });
-      vi.useFakeTimers();
-      fireEvent.click(screen.getByRole("button", { name: /submit bid/i }));
-
-      await act(async () => {
-        await Promise.resolve();
-      });
+    await waitFor(function (): void {
       expect(mockedInvoke).toHaveBeenCalledWith("make_transfer_bid", {
         playerId: "player-market-1",
         fee: 1000000,
       });
+    });
 
-      await act(async () => {
-        vi.advanceTimersByTime(2000);
-      });
+    // Modal must stay open on acceptance so the user can read the
+    // confirmation. Any auto-close reintroduces the 2-second flicker
+    // and the double-unmount of the deal workspace parent.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(
+      screen.getByRole("dialog", { name: /john smith/i }),
+    ).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    await waitFor(function (): void {
       expect(
         screen.queryByRole("dialog", { name: /john smith/i }),
       ).not.toBeInTheDocument();
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("filters free agents in the player market and opens the contract modal", async function (): Promise<void> {

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -238,11 +238,6 @@ export default function TransfersTab({
     useState<PlayerData | null>(null);
   const [dealWorkspaceKind, setDealWorkspaceKind] =
     useState<DealKind>("transfer");
-  const closeAcceptedDealWorkspace = (playerId: string) => {
-    setDealWorkspaceTarget((target) =>
-      target?.id === playerId ? null : target,
-    );
-  };
 
   useEffect(() => {
     if (!openPositionPopover) return;
@@ -473,14 +468,6 @@ export default function TransfersTab({
         }
       }
       if (onGameUpdate) onGameUpdate(response.game);
-
-      if (response.decision === "accepted") {
-        const acceptedPlayerId = loanTarget.id;
-        setTimeout(() => {
-          closeLoanOffer();
-          closeAcceptedDealWorkspace(acceptedPlayerId);
-        }, 1500);
-      }
     } catch (err: any) {
       setLoanResult("error");
       setLoanError(resolveTranslatedErrorMessage(getErrorMessage(err), t));
@@ -540,12 +527,6 @@ export default function TransfersTab({
         }
       }
       if (onGameUpdate) onGameUpdate(response.game);
-
-      if (response.decision === "accepted") {
-        setTimeout(() => {
-          closeLoanCounterOffer();
-        }, 1500);
-      }
     } catch (err: any) {
       setLoanCounterResult("error");
       setLoanCounterError(
@@ -590,14 +571,6 @@ export default function TransfersTab({
       if (response.suggested_fee !== null) {
         setCounterAmount(formatTransferFeeInput(response.suggested_fee));
       }
-      if (response.decision === "accepted") {
-        setTimeout(() => {
-          setCounterTarget(null);
-          setCounterAmount("");
-          setCounterResult(null);
-          setCounterFeedback(null);
-        }, 1500);
-      }
     } catch (err: any) {
       setCounterError(
         mapTransferNegotiationError(t, err?.toString() || "error"),
@@ -626,7 +599,6 @@ export default function TransfersTab({
   } = useTransferBidFlow({
     gameState,
     onGameUpdate,
-    onAccepted: closeAcceptedDealWorkspace,
   });
   const scouts = gameState.staff.filter(
     (staffMember) =>
@@ -873,7 +845,6 @@ export default function TransfersTab({
   } = useFreeAgentContractFlow({
     gameState,
     onGameUpdate,
-    onAccepted: closeAcceptedDealWorkspace,
   });
 
   const getDealKinds = (player: PlayerData): DealKind[] => {

--- a/src/components/transfers/useFreeAgentContractFlow.ts
+++ b/src/components/transfers/useFreeAgentContractFlow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   getRenewalStatusClassName,
@@ -19,7 +19,6 @@ import { resolveBackendError } from "../../utils/backendI18n";
 interface UseFreeAgentContractFlowArgs {
   gameState: GameStateData;
   onGameUpdate?: (game: GameStateData) => void;
-  onAccepted?: (playerId: string) => void;
 }
 
 const MARKET_VALUE_TO_WAGE_RATIO = 200;
@@ -73,7 +72,6 @@ function defaultContractWage(player: PlayerData): string {
 export function useFreeAgentContractFlow({
   gameState,
   onGameUpdate,
-  onAccepted,
 }: UseFreeAgentContractFlowArgs): UseFreeAgentContractFlowResult {
   const myTeam = gameState.teams.find(
     (team) => team.id === gameState.manager.team_id,
@@ -93,7 +91,6 @@ export function useFreeAgentContractFlow({
   const [contractSuggestedWage, setContractSuggestedWage] = useState<number | null>(null);
   const [contractSuggestedYears, setContractSuggestedYears] = useState<number | null>(null);
   const [contractIsTerminal, setContractIsTerminal] = useState(false);
-  const autoCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const offeredWage = Number(contractWage);
   const offeredYears = Number(contractLength);
@@ -106,15 +103,6 @@ export function useFreeAgentContractFlow({
     isContractWageValid &&
     contractProjection !== null &&
     !contractProjection.policy_allows;
-
-  const clearAutoCloseTimeout = (): void => {
-    if (autoCloseTimeoutRef.current !== null) {
-      clearTimeout(autoCloseTimeoutRef.current);
-      autoCloseTimeoutRef.current = null;
-    }
-  };
-
-  useEffect(() => clearAutoCloseTimeout, []);
 
   useEffect(() => {
     if (!freeAgentTarget || !isContractWageValid) {
@@ -149,7 +137,6 @@ export function useFreeAgentContractFlow({
   }, [freeAgentTarget, isContractWageValid, offeredWage]);
 
   const openFreeAgentContract = (player: PlayerData): void => {
-    clearAutoCloseTimeout();
     setFreeAgentTarget(player);
     setContractWage(defaultContractWage(player));
     setContractLength(defaultContractYears(player.date_of_birth, gameState.clock.current_date));
@@ -168,7 +155,6 @@ export function useFreeAgentContractFlow({
       return;
     }
 
-    clearAutoCloseTimeout();
     setFreeAgentTarget(null);
     setContractWage("");
     setContractLength("");
@@ -215,14 +201,6 @@ export function useFreeAgentContractFlow({
         }
       }
 
-      if (result.outcome === "accepted") {
-        const acceptedPlayerId = freeAgentTarget.id;
-        clearAutoCloseTimeout();
-        autoCloseTimeoutRef.current = setTimeout(() => {
-          closeFreeAgentContract();
-          onAccepted?.(acceptedPlayerId);
-        }, 2000);
-      }
     } catch (error) {
       setContractStatus("error");
       setContractError(resolveBackendError(error));

--- a/src/components/transfers/useTransferBidFlow.test.tsx
+++ b/src/components/transfers/useTransferBidFlow.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { JSX } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -177,14 +177,12 @@ function createGameState(players: PlayerData[] = [createPlayer()]): GameStateDat
 function HookHarness({
     gameState,
     target,
-    onAccepted,
 }: {
     gameState: GameStateData;
     target: PlayerData;
-    onAccepted?: (playerId: string) => void;
 }): JSX.Element {
     const { bidAmount, bidResult, setBidAmount, openBidNegotiation, handleMakeBid } =
-        useTransferBidFlow({ gameState, onAccepted });
+        useTransferBidFlow({ gameState });
 
     return (
         <div>
@@ -246,54 +244,38 @@ describe("useTransferBidFlow", function (): void {
         });
     });
 
-    it("cancels the accepted-bid auto-close timeout on unmount", async function (): Promise<void> {
-        vi.useFakeTimers();
-        try {
-            const target = createPlayer();
-            const gameState = createGameState([target]);
-            const onAccepted = vi.fn();
-            mockedMakeTransferBid.mockResolvedValue({
-                decision: "accepted",
-                suggested_fee: null,
-                is_terminal: true,
-                feedback: {
-                    mood: "positive",
-                    headline_key: "transfers.transferFeedbackAcceptedHeadline",
-                    detail_key: "transfers.transferFeedbackAcceptedDetail",
-                    tension: 20,
-                    patience: 80,
-                    round: 1,
-                    params: { fee: "1500000" },
-                },
-                game: gameState,
-            });
+    it("keeps the acceptance state visible so the modal does not auto-close", async function (): Promise<void> {
+        const target = createPlayer();
+        const gameState = createGameState([target]);
+        mockedMakeTransferBid.mockResolvedValue({
+            decision: "accepted",
+            suggested_fee: null,
+            is_terminal: true,
+            feedback: {
+                mood: "positive",
+                headline_key: "transfers.transferFeedbackAcceptedHeadline",
+                detail_key: "transfers.transferFeedbackAcceptedDetail",
+                tension: 20,
+                patience: 80,
+                round: 1,
+                params: { fee: "1500000" },
+            },
+            game: gameState,
+        });
 
-            const { unmount } = render(
-                <HookHarness
-                    gameState={gameState}
-                    target={target}
-                    onAccepted={onAccepted}
-                />,
-            );
+        render(<HookHarness gameState={gameState} target={target} />);
 
-            fireEvent.click(screen.getByRole("button", { name: "Open" }));
-            fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+        fireEvent.click(screen.getByRole("button", { name: "Open" }));
+        fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-            await act(async function flushAcceptedBid(): Promise<void> {
-                await Promise.resolve();
-            });
-
+        await waitFor(function (): void {
             expect(screen.getByLabelText("bid-result")).toHaveTextContent("accepted");
+        });
 
-            unmount();
-
-            act(function advanceAutoCloseTimer(): void {
-                vi.advanceTimersByTime(2000);
-            });
-
-            expect(onAccepted).not.toHaveBeenCalled();
-        } finally {
-            vi.useRealTimers();
-        }
+        // No auto-close: the accepted state must persist until the caller
+        // explicitly closes the modal. Regressions here reintroduce the
+        // 2-second flicker that hid the acceptance confirmation.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(screen.getByLabelText("bid-result")).toHaveTextContent("accepted");
     });
 });

--- a/src/components/transfers/useTransferBidFlow.test.tsx
+++ b/src/components/transfers/useTransferBidFlow.test.tsx
@@ -274,8 +274,9 @@ describe("useTransferBidFlow", function (): void {
 
         // No auto-close: the accepted state must persist until the caller
         // explicitly closes the modal. Regressions here reintroduce the
-        // 2-second flicker that hid the acceptance confirmation.
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // 2-second flicker that hid the acceptance confirmation. Wait
+        // past the old 2s timer so the guard actually catches its return.
+        await new Promise((resolve) => setTimeout(resolve, 2100));
         expect(screen.getByLabelText("bid-result")).toHaveTextContent("accepted");
     });
 });

--- a/src/components/transfers/useTransferBidFlow.ts
+++ b/src/components/transfers/useTransferBidFlow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import type {
     GameStateData,
@@ -23,7 +23,6 @@ import {
 interface UseTransferBidFlowArgs {
     gameState: GameStateData;
     onGameUpdate?: (game: GameStateData) => void;
-    onAccepted?: (playerId: string) => void;
 }
 
 interface UseTransferBidFlowResult {
@@ -47,7 +46,6 @@ interface UseTransferBidFlowResult {
 export function useTransferBidFlow({
     gameState,
     onGameUpdate,
-    onAccepted,
 }: UseTransferBidFlowArgs): UseTransferBidFlowResult {
     const userTeamId = gameState.manager.team_id;
     const myTeam = gameState.teams.find(
@@ -63,7 +61,6 @@ export function useTransferBidFlow({
         useState<TransferNegotiationFeedbackData | null>(null);
     const [bidProjection, setBidProjection] =
         useState<TransferBidProjectionData["projection"] | null>(null);
-    const autoCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const activeBidOffer = bidTarget
         ? getOutgoingNegotiationOffer(bidTarget, userTeamId)
@@ -72,15 +69,6 @@ export function useTransferBidFlow({
     const bidFee = Number.isFinite(bidAmountMillions)
         ? Math.round(bidAmountMillions * 1_000_000)
         : null;
-
-    const clearAutoCloseTimeout = (): void => {
-        if (autoCloseTimeoutRef.current !== null) {
-            clearTimeout(autoCloseTimeoutRef.current);
-            autoCloseTimeoutRef.current = null;
-        }
-    };
-
-    useEffect(() => clearAutoCloseTimeout, []);
 
     useEffect(() => {
         if (!bidTarget || bidFee === null || bidFee <= 0) {
@@ -117,7 +105,6 @@ export function useTransferBidFlow({
     const openBidNegotiation = (player: PlayerData): void => {
         const existingOffer = getOutgoingNegotiationOffer(player, userTeamId);
 
-        clearAutoCloseTimeout();
         setBidTarget(player);
         setBidAmount(
             (
@@ -133,7 +120,6 @@ export function useTransferBidFlow({
     };
 
     const closeBidNegotiation = (): void => {
-        clearAutoCloseTimeout();
         setBidTarget(null);
         setBidAmount("");
         setBidResult(null);
@@ -158,16 +144,6 @@ export function useTransferBidFlow({
 
             if (response.suggested_fee !== null) {
                 setBidAmount(formatTransferFeeInput(response.suggested_fee));
-            }
-
-            if (response.decision === "accepted") {
-                const acceptedPlayerId = bidTarget.id;
-                clearAutoCloseTimeout();
-                autoCloseTimeoutRef.current = setTimeout(() => {
-                    autoCloseTimeoutRef.current = null;
-                    closeBidNegotiation();
-                    onAccepted?.(acceptedPlayerId);
-                }, 2000);
             }
         } catch (error: any) {
             setBidResult(error?.toString() || "error");


### PR DESCRIPTION
This is fixing two issues:

- When the transfer was accepted, 2 seconds later the modal was closed automatically, which is pretty short to get the small message the transfer was accepted. There is a close button, so I guess its safe to leave it to the user to close. This also opens the opportunity to move to the wage negotiations after transfer is settled. #275 
- When a transfer gets executed, the transfer budget is not reduced 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer budgets now refresh at the end of each season based on 15% of team finances (clamped to avoid negative budgets), keeping the transfer market properly stocked.
  * Completing a transfer now deducts the fee from both club funds and the buyer’s transfer budget, so available spending reflects actual purchases.
  * Accepted transfer bid and contract outcomes remain visible instead of auto-closing, so you can review results without interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->