### PR TITLE
fix(training): stop attribute gains for peaked players (#307)

### DIFF
--- a/src-tauri/crates/ofm_core/src/training.rs
+++ b/src-tauri/crates/ofm_core/src/training.rs
@@ -285,7 +285,13 @@ fn train_player(
         * plan.bonus.coaching_mult
         * plan.bonus.specialization_mult;
 
-    apply_focus_gains(&mut player.attributes, player_focus, gain, rng);
+    // Peaked players (ovr == potential) get no attribute gains. Without this
+    // gate, attribute drift lifts ovr, and `refresh_player_derived`'s
+    // `potential = max(potential, ovr)` invariant silently raises the career
+    // ceiling in lockstep — the ceiling stops being a ceiling.
+    if player.potential > player.ovr {
+        apply_focus_gains(&mut player.attributes, player_focus, gain, rng);
+    }
     apply_fitness_change(&mut player.fitness, player_focus, intensity_mult, rng);
 
     // Refresh position-weighted OVR and traits after attribute gains.

--- a/src-tauri/crates/ofm_core/tests/training_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/training_tests.rs
@@ -5,6 +5,7 @@ use domain::staff::{Staff, StaffAttributes, StaffRole};
 use domain::team::{Team, TrainingFocus, TrainingIntensity, TrainingSchedule};
 use ofm_core::clock::GameClock;
 use ofm_core::game::Game;
+use ofm_core::player_rating::refresh_player_derived;
 use ofm_core::training;
 
 // ---------------------------------------------------------------------------
@@ -1066,5 +1067,78 @@ fn ai_fatigue_guard_rests_exhausted_ai_player_but_not_user_team() {
     assert!(
         ai_after > user_after,
         "guarded AI player ({ai_after}) should end fresher than the user player ({user_after})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// process_training — potential ceiling (issue #307)
+//
+// Peaked players (ovr == potential) must not keep gaining. Attribute-driven OVR
+// growth combined with the `potential = max(potential, ovr)` safety net causes
+// the career ceiling to rise in lockstep with the drift when this contract is
+// not enforced at the training-gain site.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn peaked_player_does_not_gain_from_training() {
+    let mut game = make_game();
+    game.teams[0].training_focus = TrainingFocus::Physical;
+    game.teams[0].training_intensity = TrainingIntensity::High;
+    game.teams[0].training_schedule = TrainingSchedule::Intense;
+
+    // Prime-age player (age ~27 in 2025). Compute their natural OVR from
+    // default_attrs, then peg potential to it so they have no headroom.
+    let year = game.clock.current_date.date_naive().format("%Y").to_string();
+    let year: u32 = year.parse().unwrap();
+    let peaked_id = "p2".to_string();
+    {
+        let p = game
+            .players
+            .iter_mut()
+            .find(|p| p.id == peaked_id)
+            .expect("prime player exists");
+        refresh_player_derived(p, year);
+        p.potential = p.ovr;
+    }
+
+    let initial_ovr = game
+        .players
+        .iter()
+        .find(|p| p.id == peaked_id)
+        .unwrap()
+        .ovr;
+    let initial_potential = game
+        .players
+        .iter()
+        .find(|p| p.id == peaked_id)
+        .unwrap()
+        .potential;
+    assert_eq!(
+        initial_ovr, initial_potential,
+        "test precondition: peaked player starts with ovr == potential"
+    );
+
+    // Run many training sessions with condition kept high so the AI fatigue
+    // guard doesn't intervene.
+    for _ in 0..150 {
+        for p in game.players.iter_mut() {
+            p.condition = 90;
+        }
+        training::process_training(&mut game, 0); // Monday, Intense trains Mon
+    }
+
+    let final_player = game.players.iter().find(|p| p.id == peaked_id).unwrap();
+
+    assert_eq!(
+        final_player.potential, initial_potential,
+        "peaked player's potential must not rise from training (bug #307): \
+         potential drifted {} → {}",
+        initial_potential, final_player.potential
+    );
+    assert_eq!(
+        final_player.ovr, initial_ovr,
+        "peaked player's ovr must not rise from training (bug #307): \
+         ovr drifted {} → {}",
+        initial_ovr, final_player.ovr
     );
 }

--- a/src-tauri/crates/ofm_core/tests/training_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/training_tests.rs
@@ -1101,18 +1101,20 @@ fn peaked_player_does_not_gain_from_training() {
         p.potential = p.ovr;
     }
 
-    let initial_ovr = game
+    let initial = game
         .players
         .iter()
         .find(|p| p.id == peaked_id)
-        .unwrap()
-        .ovr;
-    let initial_potential = game
-        .players
-        .iter()
-        .find(|p| p.id == peaked_id)
-        .unwrap()
-        .potential;
+        .unwrap();
+    let initial_ovr = initial.ovr;
+    let initial_potential = initial.potential;
+    // Snapshot the exact attributes Physical focus would try to grow so the
+    // regression catches a partial gate that still lets one attribute leak
+    // through even when the aggregated ovr happens not to move.
+    let initial_pace = initial.attributes.pace;
+    let initial_stamina = initial.attributes.stamina;
+    let initial_strength = initial.attributes.strength;
+    let initial_agility = initial.attributes.agility;
     assert_eq!(
         initial_ovr, initial_potential,
         "test precondition: peaked player starts with ovr == potential"
@@ -1129,6 +1131,22 @@ fn peaked_player_does_not_gain_from_training() {
 
     let final_player = game.players.iter().find(|p| p.id == peaked_id).unwrap();
 
+    assert_eq!(
+        final_player.attributes.pace, initial_pace,
+        "peaked player's pace must not rise from Physical training (bug #307)"
+    );
+    assert_eq!(
+        final_player.attributes.stamina, initial_stamina,
+        "peaked player's stamina must not rise from Physical training (bug #307)"
+    );
+    assert_eq!(
+        final_player.attributes.strength, initial_strength,
+        "peaked player's strength must not rise from Physical training (bug #307)"
+    );
+    assert_eq!(
+        final_player.attributes.agility, initial_agility,
+        "peaked player's agility must not rise from Physical training (bug #307)"
+    );
     assert_eq!(
         final_player.potential, initial_potential,
         "peaked player's potential must not rise from training (bug #307): \


### PR DESCRIPTION
## Summary

- Closes #307 — peaked players (`ovr == potential`) no longer gain attributes from training, which stops the `potential = max(potential, ovr)` safety net from silently raising the career ceiling.
- Reporter's evidence: over 29 in-game days, a peaked 25-year-old drifted `57/57 → 63/63` with matching attribute gains. Same fingerprint across separate saves (Wright `69/69→78/78`, Renard `66/66→72/72`, Connolly `53/53→67/67`).

## Fix

One-line gate in `train_player` before `apply_focus_gains`:

```rust
if player.potential > player.ovr {
    apply_focus_gains(&mut player.attributes, player_focus, gain, rng);
}
```

Fitness change, condition cost/recovery, and the `potential = max(potential, ovr)` invariant in `refresh_player_derived` are deliberately untouched — the invariant is protecting a contract, not causing the drift.

## Test plan

- [x] New regression test `peaked_player_does_not_gain_from_training` peaks a prime-age player at their computed OVR, trains 150 intense Physical sessions with condition held high (bypassing the fatigue guard), and asserts both `ovr` and `potential` are unchanged. Fails without the fix (`potential drifted 65 → 69`), passes with it.
- [x] `cargo test -p ofm_core` — 900+ tests green. `young_player_gains_more_than_old` and `physical_focus_can_improve_physical_attrs` still pass, confirming young / non-peaked players still develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Training no longer increases tracked attributes for “peaked” players who have reached their current ceiling (no attribute gains when potential is not above current OVR), preventing unintended OVR/potential drift.

* **Tests**
  * Added a regression test (issue `#307`) ensuring high-condition training does not change attributes, OVR, or potential for peaked players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->