### PR TITLE
test(match): lock in that MAX/paused don't persist across half-time (#106)

### DIFF
--- a/src/components/match/MatchLive.tsx
+++ b/src/components/match/MatchLive.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
 import { GameStateData } from "../../store/gameStore";
-import { MatchSnapshot, MatchEvent, MinuteResult, SimSpeed, SPEED_MS, FORMATIONS } from "./types";
+import { MatchSnapshot, MatchEvent, MinuteResult, SimSpeed, SPEED_MS, FORMATIONS, isPersistableSpeed } from "./types";
 import { getEventDisplay, getPlayerName, makeTeamFallback, phaseLabel } from "./helpers";
 import { Badge, TeamLogo } from "../ui";
 import { useSettingsStore } from "../../store/settingsStore";
@@ -331,7 +331,7 @@ export default function MatchLive({
                   onClick={() => {
                     setSpeed(s.id);
                     setIsRunning(s.id !== "paused");
-                    if (s.id !== "paused" && s.id !== "instant") {
+                    if (isPersistableSpeed(s.id)) {
                       onPreferredSpeedChange?.(s.id);
                     }
                   }}

--- a/src/components/match/helpers.test.ts
+++ b/src/components/match/helpers.test.ts
@@ -8,7 +8,7 @@ import {
   resolveMatchFixture,
 } from "./helpers";
 import i18n, { i18nReady } from "../../i18n";
-import { getTeamTalkOptions } from "./types";
+import { getTeamTalkOptions, isPersistableSpeed } from "./types";
 import type { MatchSnapshot, EnginePlayerData, EngineTeamData } from "./types";
 import type { GameStateData } from "../../store/gameStore";
 
@@ -328,5 +328,23 @@ describe("getTeamTalkOptions", () => {
       label: "Loda",
       description: "Dì alla squadra che finora è stata eccellente.",
     });
+  });
+});
+
+describe("isPersistableSpeed", () => {
+  it("marks playback speeds as persistable", () => {
+    expect(isPersistableSpeed("slow")).toBe(true);
+    expect(isPersistableSpeed("normal")).toBe(true);
+    expect(isPersistableSpeed("fast")).toBe(true);
+  });
+
+  // Locks in the design of #106: `paused` is a temporary action; `instant`
+  // is a one-shot skip-to-end-of-half. Persisting either across half-time
+  // would either resume paused (surprising) or silently skip the whole
+  // second half (worse). Only "slow" / "normal" / "fast" describe a pace
+  // worth resuming from.
+  it("marks one-shot speeds as non-persistable so they don't resume after half-time", () => {
+    expect(isPersistableSpeed("paused")).toBe(false);
+    expect(isPersistableSpeed("instant")).toBe(false);
   });
 });

--- a/src/components/match/types.ts
+++ b/src/components/match/types.ts
@@ -175,6 +175,16 @@ export interface RoundSummary {
 
 export type SimSpeed = "paused" | "slow" | "normal" | "fast" | "instant";
 
+// A "persistable" speed is a playback pace the user might want to resume from
+// after half-time. `paused` is a temporary action; `instant` is a one-shot
+// skip-to-end-of-half — persisting it would silently skip the next half.
+// Only "slow" / "normal" / "fast" describe a pace worth locking in.
+export function isPersistableSpeed(
+  s: SimSpeed,
+): s is "slow" | "normal" | "fast" {
+  return s !== "paused" && s !== "instant";
+}
+
 export type MatchDayStage =
   | "prematch"
   | "first_half"


### PR DESCRIPTION
## Summary

While manually verifying #106 on develop I found the fix works for slow/normal/fast — the parent state persists across half-time — but the intent that **MAX (`instant`) and paused must _not_ persist** lived only as an inline boolean in `MatchLive.tsx:334`:

\`\`\`ts
if (s.id !== \"paused\" && s.id !== \"instant\") {
  onPreferredSpeedChange?.(s.id);
}
\`\`\`

No test names or covers this — the existing test at \`MatchSimulation.test.tsx:585\` stubs \`MatchLive\` and only exercises \`\"fast\"\`. A future refactor could easily broaden the propagation and quietly reintroduce the exact regression #106 solved (second half auto-skips because \`instant\` was persisted).

## Change

- **\`types.ts\`** — extract the invariant as \`isPersistableSpeed(s: SimSpeed): s is \"slow\" | \"normal\" | \"fast\"\`, sitting next to \`SimSpeed\` with a comment explaining why paused/instant are excluded.
- **\`MatchLive.tsx\`** — click handler now reads \`if (isPersistableSpeed(s.id))\`. Behavior identical.
- **\`helpers.test.ts\`** — two tests: playback speeds persist; one-shot speeds don't, tied back to #106 in a comment so a future refactor gets a clear signal.

No behavior change. Preserves the fix that landed in PR #245 (commit \`1475807b\`).

## Test plan

- [x] \`npx vitest run src/components/match/helpers.test.ts\` — 26 passed (2 new)
- [x] \`npx vitest run src/pages/MatchSimulation.test.tsx src/components/match/\` — 124 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speed preferences are now saved only for regular playback speeds, preventing paused or instant modes from being stored unexpectedly.
  * Match speed controls now behave more consistently when switching between different simulation speeds.

* **Tests**
  * Added coverage for which playback speeds are considered saveable and which are not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->