### PR TITLE
fix(renewals): compare renewal_state.status against PascalCase wire shape (#193)

### DIFF
--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -1166,7 +1166,7 @@ describe("PlayerProfile contract surfaces", () => {
       morale_core: {
         manager_trust: 50,
         renewal_state: {
-          status: "blocked",
+          status: "Blocked",
           manager_blocked_until: null,
           last_attempt_date: "2026-08-01",
           last_assistant_attempt_date: null,
@@ -1213,6 +1213,43 @@ describe("PlayerProfile contract surfaces", () => {
       });
       expect(screen.getByRole("button", { name: "Let Expire" })).toBeInTheDocument();
     });
+  });
+
+  // Regression for #193 / follow-up on PR #245.
+  //
+  // Backend `RenewalSessionStatus::Blocked` serializes as `"Blocked"` (PascalCase)
+  // — serde's default enum representation. The PR #245 fix compared against a
+  // lowercase `"blocked"` literal, so the guard was always false and the block
+  // was never restored on modal reopen. Existing fixtures used lowercase too,
+  // so they matched the buggy frontend and the bug slipped through. This test
+  // uses the real wire shape and asserts the modal opens in terminal (blocked)
+  // state — only the "Done" button, no Submit path.
+  it("restores blocked state when reopening the renewal modal after being blocked", async () => {
+    const blockedPlayer = createPlayer({
+      morale_core: {
+        manager_trust: 30,
+        renewal_state: {
+          status: "Blocked",
+          manager_blocked_until: "2099-01-01",
+          last_attempt_date: "2026-08-01",
+          last_assistant_attempt_date: null,
+          last_outcome: "BlockedByManager",
+          conversation_round: 1,
+          exit_intent: null,
+        },
+      },
+    });
+
+    render(<RenewalHarness initialPlayer={blockedPlayer} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Renew Contract" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Submit Offer" }),
+    ).not.toBeInTheDocument();
   });
 
   it("localizes contract action failures instead of showing raw backend keys", async () => {

--- a/src/components/playerProfile/PlayerProfile.tsx
+++ b/src/components/playerProfile/PlayerProfile.tsx
@@ -269,7 +269,7 @@ export default function PlayerProfile({
     const renewalState = player.morale_core?.renewal_state;
     const blockedUntil = renewalState?.manager_blocked_until;
     const hasActiveManagerBlock =
-      renewalState?.status === "blocked" &&
+      renewalState?.status === "Blocked" &&
       (!blockedUntil ||
         blockedUntil.slice(0, 10) >= gameState.clock.current_date.slice(0, 10));
     if (hasActiveManagerBlock) {

--- a/src/components/squad/SquadTab.test.tsx
+++ b/src/components/squad/SquadTab.test.tsx
@@ -416,7 +416,7 @@ describe("SquadTab", () => {
     gameState.players[0].morale_core = {
       manager_trust: 50,
       renewal_state: {
-        status: "blocked",
+        status: "Blocked",
         manager_blocked_until: null,
         last_attempt_date: "2026-08-01",
         last_assistant_attempt_date: null,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -203,7 +203,11 @@ export interface ContractExitIntentData {
 }
 
 export interface ContractRenewalStateData {
-  status: "idle" | "open" | "agreed" | "blocked" | "stalled";
+  // Backend `RenewalSessionStatus` (domain/player.rs) uses serde default enum
+  // representation — PascalCase variant names on the wire. Do not confuse with
+  // the lowercase `session_status` in command responses, which goes through a
+  // dedicated `serialize_session_status()` helper on the Rust side.
+  status: "Idle" | "Open" | "Agreed" | "Blocked" | "Stalled";
   manager_blocked_until?: string | null;
   last_attempt_date?: string | null;
   last_assistant_attempt_date?: string | null;


### PR DESCRIPTION
## Summary

Closes #193.

PR #245 shipped a block-guard for the renewal modal that read
\`player.morale_core.renewal_state.status === \"blocked\"\` on open. The
backend's \`RenewalSessionStatus\` enum has no \`#[serde(rename_all)]\`,
so serde default emits **\`\"Blocked\"\` (PascalCase)** on the wire. The
lowercase compare was always false, \`hasActiveManagerBlock\` never
fired, and the block was never restored — exact reported behaviour in
#193.

Existing fixtures used \`\"blocked\"\` too, so tests agreed with the
buggy frontend and nothing caught it. \`grep\`-ing found only one
reader of the field, so the drift didn't break anything else.

## Changes

- **\`PlayerProfile.tsx\`** — compare against \`\"Blocked\"\`.
- **\`store/types.ts\`** — tighten \`ContractRenewalStateData.status\` to
  the PascalCase variants matching the backend, with a comment noting
  the deliberate contrast with \`session_status\` on command responses
  (which is lowercased by a dedicated \`serialize_session_status()\`
  helper on the Rust side — different field, different serialization).
- **Fixture fixes** — \`PlayerProfile.test.tsx\` and \`SquadTab.test.tsx\`
  flip their stale lowercase literals so the test suite stops lying
  about the wire shape.
- **New regression test** — \`PlayerProfile.test.tsx\` renders a player
  with \`status: \"Blocked\"\` + a future \`manager_blocked_until\`, opens
  the renewal modal, and asserts the terminal UI (\"Done\", no \"Submit
  Offer\"). Fails on the old lowercase compare; passes now.

## Class-of-bug follow-up

The root cause here is two independent sources of truth for the same
Rust enum: TS hand-mirrors the wire format and drift is invisible to
the compiler. Filed separately (codegen discussion issue coming) so
this class of bug can't slip past review again.

## Test plan

- [x] \`npx tsc --noEmit\` — no errors after tightening the union
- [x] \`npx vitest run\` — 1059 tests pass, incl. the new regression
- [ ] Manually: offer an insulting wage → block set → close modal / navigate away → reopen from player profile → modal opens in Done-only state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected renewal status handling so blocked players are recognized properly in the renewal flow.
  * Fixed renewal/contract modal behavior to show the terminal blocked state with a **Done** button instead of offering submission options.
  * Updated related test coverage to match the corrected status format and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->