### PR TITLE
fix(a11y): label player action menus and add keyboard/screen-reader paths (#311)

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -28,14 +28,23 @@ export interface ContextMenuHandle {
 interface ContextMenuProps {
   items: ContextMenuItem[];
   children: React.ReactNode;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
-  function ContextMenu({ items, children }, ref) {
+  function ContextMenu({ items, children, onOpenChange }, ref) {
     const [visible, setVisible] = useState(false);
     const [pos, setPos] = useState({ x: 0, y: 0 });
     const menuRef = useRef<HTMLDivElement>(null);
     const instanceId = useRef(Math.random().toString(36));
+
+    const setOpen = useCallback((next: boolean) => {
+      setVisible(next);
+    }, []);
+
+    useEffect(() => {
+      onOpenChange?.(visible);
+    }, [visible, onOpenChange]);
 
     const openAt = useCallback((x: number, y: number) => {
       window.dispatchEvent(
@@ -44,8 +53,8 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
       const clampedX = Math.min(x, window.innerWidth - 200);
       const clampedY = Math.min(y, window.innerHeight - 300);
       setPos({ x: clampedX, y: clampedY });
-      setVisible(true);
-    }, []);
+      setOpen(true);
+    }, [setOpen]);
 
     useImperativeHandle(ref, () => ({ open: openAt }), [openAt]);
 
@@ -58,23 +67,28 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
     useEffect(() => {
       const closeFromOther = (e: Event) => {
         const detail = (e as CustomEvent).detail;
-        if (detail !== instanceId.current) setVisible(false);
+        if (detail !== instanceId.current) setOpen(false);
       };
       window.addEventListener("close-context-menus", closeFromOther);
       return () =>
         window.removeEventListener("close-context-menus", closeFromOther);
-    }, []);
+    }, [setOpen]);
 
     useEffect(() => {
       if (!visible) return;
-      const close = () => setVisible(false);
+      const close = () => setOpen(false);
+      const closeOnEscape = (e: KeyboardEvent) => {
+        if (e.key === "Escape") setOpen(false);
+      };
       window.addEventListener("click", close);
       window.addEventListener("scroll", close, true);
+      window.addEventListener("keydown", closeOnEscape);
       return () => {
         window.removeEventListener("click", close);
         window.removeEventListener("scroll", close, true);
+        window.removeEventListener("keydown", closeOnEscape);
       };
-    }, [visible]);
+    }, [visible, setOpen]);
 
     const trigger = isValidElement(children) ? (
       cloneElement(children, {
@@ -119,9 +133,10 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
                 ) : (
                   <button
                     key={i}
+                    role="menuitem"
                     onClick={() => {
                       item.onClick?.();
-                      setVisible(false);
+                      setOpen(false);
                     }}
                     disabled={item.disabled}
                     className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2.5 transition-colors ${

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -40,9 +40,19 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
     const triggerRef = useRef<HTMLElement | null>(null);
 
     const setOpen = useCallback((next: boolean) => {
-      setVisible(next);
-      onOpenChange?.(next);
+      // Notify only on real transitions so consumers wiring aria-expanded on
+      // their trigger don't get spurious "closed" pings when closeFromOther
+      // fires while we're already closed.
+      setVisible((prev) => {
+        if (prev !== next) onOpenChange?.(next);
+        return next;
+      });
     }, [onOpenChange]);
+
+    const closeAndRestoreFocus = useCallback(() => {
+      setOpen(false);
+      triggerRef.current?.focus();
+    }, [setOpen]);
 
     const openAt = useCallback((x: number, y: number) => {
       window.dispatchEvent(
@@ -78,18 +88,23 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
       const close = () => setOpen(false);
       const closeOnEscape = (e: KeyboardEvent) => {
         if (e.key !== "Escape") return;
-        setOpen(false);
-        triggerRef.current?.focus();
+        closeAndRestoreFocus();
       };
       window.addEventListener("click", close);
       window.addEventListener("scroll", close, true);
       window.addEventListener("keydown", closeOnEscape);
+      // Move keyboard focus into the menu so arrow-key navigation / Enter
+      // selection is available without tabbing through the rest of the page.
+      const firstItem = menuRef.current?.querySelector<HTMLButtonElement>(
+        'button[role="menuitem"]:not([disabled])',
+      );
+      firstItem?.focus();
       return () => {
         window.removeEventListener("click", close);
         window.removeEventListener("scroll", close, true);
         window.removeEventListener("keydown", closeOnEscape);
       };
-    }, [visible, setOpen]);
+    }, [visible, setOpen, closeAndRestoreFocus]);
 
     const trigger = isValidElement(children) ? (
       cloneElement(children, {
@@ -137,7 +152,7 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
                     role="menuitem"
                     onClick={() => {
                       item.onClick?.();
-                      setOpen(false);
+                      closeAndRestoreFocus();
                     }}
                     disabled={item.disabled}
                     className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2.5 transition-colors ${

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -38,16 +38,21 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
     const menuRef = useRef<HTMLDivElement>(null);
     const instanceId = useRef(Math.random().toString(36));
     const triggerRef = useRef<HTMLElement | null>(null);
+    const onOpenChangeRef = useRef(onOpenChange);
+
+    useEffect(() => {
+      onOpenChangeRef.current = onOpenChange;
+    }, [onOpenChange]);
 
     const setOpen = useCallback((next: boolean) => {
       // Notify only on real transitions so consumers wiring aria-expanded on
       // their trigger don't get spurious "closed" pings when closeFromOther
       // fires while we're already closed.
       setVisible((prev) => {
-        if (prev !== next) onOpenChange?.(next);
+        if (prev !== next) onOpenChangeRef.current?.(next);
         return next;
       });
-    }, [onOpenChange]);
+    }, []);
 
     const closeAndRestoreFocus = useCallback(() => {
       setOpen(false);

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -37,19 +37,18 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
     const [pos, setPos] = useState({ x: 0, y: 0 });
     const menuRef = useRef<HTMLDivElement>(null);
     const instanceId = useRef(Math.random().toString(36));
+    const triggerRef = useRef<HTMLElement | null>(null);
 
     const setOpen = useCallback((next: boolean) => {
       setVisible(next);
-    }, []);
-
-    useEffect(() => {
-      onOpenChange?.(visible);
-    }, [visible, onOpenChange]);
+      onOpenChange?.(next);
+    }, [onOpenChange]);
 
     const openAt = useCallback((x: number, y: number) => {
       window.dispatchEvent(
         new CustomEvent("close-context-menus", { detail: instanceId.current }),
       );
+      triggerRef.current = document.activeElement as HTMLElement | null;
       const clampedX = Math.min(x, window.innerWidth - 200);
       const clampedY = Math.min(y, window.innerHeight - 300);
       setPos({ x: clampedX, y: clampedY });
@@ -78,7 +77,9 @@ const ContextMenu = forwardRef<ContextMenuHandle, ContextMenuProps>(
       if (!visible) return;
       const close = () => setOpen(false);
       const closeOnEscape = (e: KeyboardEvent) => {
-        if (e.key === "Escape") setOpen(false);
+        if (e.key !== "Escape") return;
+        setOpen(false);
+        triggerRef.current?.focus();
       };
       window.addEventListener("click", close);
       window.addEventListener("scroll", close, true);

--- a/src/components/dashboard/DashboardHeader.test.tsx
+++ b/src/components/dashboard/DashboardHeader.test.tsx
@@ -144,7 +144,7 @@ describe("DashboardHeader", () => {
         );
 
         fireEvent.contextMenu(screen.getByTestId("dashboard-search-player-player-1"));
-        fireEvent.click(screen.getByRole("button", { name: "View team" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
         expect(onSelectSearchTeam).toHaveBeenCalledWith("team-1");
         expect(onSelectSearchPlayer).not.toHaveBeenCalled();

--- a/src/components/home/HomeRecentMessagesCard.test.tsx
+++ b/src/components/home/HomeRecentMessagesCard.test.tsx
@@ -76,7 +76,7 @@ describe("HomeRecentMessagesCard", () => {
     );
 
     fireEvent.contextMenu(screen.getByText("Welcome"));
-    fireEvent.click(screen.getByRole("button", { name: "Open message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open message" }));
 
     expect(onNavigate).toHaveBeenCalledWith("Inbox", { messageId: "message-1" });
   });

--- a/src/components/inbox/InboxTab.test.tsx
+++ b/src/components/inbox/InboxTab.test.tsx
@@ -450,7 +450,7 @@ describe("InboxTab", function (): void {
     });
 
     fireEvent.contextMenu(screen.getByTestId("inbox-row-m1"));
-    fireEvent.click(screen.getByRole("button", { name: "Delete message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete message" }));
 
     expect(
       screen.getByTestId("inbox-delete-confirm-modal"),

--- a/src/components/manager/ManagerTab.test.tsx
+++ b/src/components/manager/ManagerTab.test.tsx
@@ -147,12 +147,12 @@ describe("ManagerTab", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("manager-current-team"));
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-1");
 
     fireEvent.contextMenu(screen.getByTestId("manager-history-team-0"));
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-0");
   });

--- a/src/components/match/PreMatchLineup.test.tsx
+++ b/src/components/match/PreMatchLineup.test.tsx
@@ -275,7 +275,7 @@ describe("PreMatchLineup component", () => {
 
     fireEvent.contextMenu(screen.getByTestId("pre-match-starter-m1"));
     fireEvent.click(
-      within(screen.getByRole("menu")).getByRole("button", {
+      within(screen.getByRole("menu")).getByRole("menuitem", {
         name: "Select for swap",
       }),
     );
@@ -302,7 +302,7 @@ describe("PreMatchLineup component", () => {
 
     fireEvent.contextMenu(screen.getByTestId("pre-match-starter-m1"));
     fireEvent.click(
-      within(screen.getByRole("menu")).getByRole("button", {
+      within(screen.getByRole("menu")).getByRole("menuitem", {
         name: "match.cancel",
       }),
     );
@@ -330,7 +330,7 @@ describe("PreMatchLineup component", () => {
 
     fireEvent.contextMenu(screen.getByTestId("pre-match-bench-b1"));
     fireEvent.click(
-      within(screen.getByRole("menu")).getByRole("button", {
+      within(screen.getByRole("menu")).getByRole("menuitem", {
         name: "Swap with selected starter",
       }),
     );

--- a/src/components/match/SubPanel.test.tsx
+++ b/src/components/match/SubPanel.test.tsx
@@ -160,7 +160,7 @@ describe("SubPanel", () => {
         fireEvent.contextMenu(screen.getByTestId("sub-panel-bench-bench-1"));
 
         expect(
-            screen.getByRole("button", { name: "Select player to take off first" }),
+            screen.getByRole("menuitem", { name: "Select player to take off first" }),
         ).toBeDisabled();
     });
 
@@ -172,10 +172,10 @@ describe("SubPanel", () => {
         );
 
         fireEvent.contextMenu(screen.getByTestId("sub-panel-off-starter-1"));
-        fireEvent.click(screen.getByRole("button", { name: "Select to take off" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Select to take off" }));
 
         fireEvent.contextMenu(screen.getByTestId("sub-panel-bench-bench-1"));
-        fireEvent.click(screen.getByRole("button", { name: "Select replacement" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Select replacement" }));
 
         fireEvent.click(
             screen.getByRole("button", { name: "Confirm substitution" }),
@@ -192,12 +192,12 @@ describe("SubPanel", () => {
         );
 
         fireEvent.contextMenu(screen.getByTestId("sub-panel-off-starter-1"));
-        fireEvent.click(screen.getByRole("button", { name: "Select to take off" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Select to take off" }));
 
         expect(screen.getByText("match.selectBenchToCompare")).toBeInTheDocument();
 
         fireEvent.contextMenu(screen.getByTestId("sub-panel-off-starter-1"));
-        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Cancel" }));
 
         expect(screen.queryByText("match.selectBenchToCompare")).not.toBeInTheDocument();
     });

--- a/src/components/news/NewsTab.test.tsx
+++ b/src/components/news/NewsTab.test.tsx
@@ -156,7 +156,7 @@ describe("NewsTab", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("news-article-news-1"));
-    fireEvent.click(screen.getByRole("button", { name: "View team: Beta FC" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team: Beta FC" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
   });

--- a/src/components/playerProfile/PlayerProfile.test.tsx
+++ b/src/components/playerProfile/PlayerProfile.test.tsx
@@ -564,7 +564,7 @@ describe("PlayerProfile contract surfaces", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("player-profile-team-link"));
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-1");
   });

--- a/src/components/playerProfile/PlayerProfileActionsMenu.tsx
+++ b/src/components/playerProfile/PlayerProfileActionsMenu.tsx
@@ -69,6 +69,7 @@ export default function PlayerProfileActionsMenu({
     const { t } = useTranslation();
     const menuRef = useRef<ContextMenuHandle>(null);
     const [mutationPending, setMutationPending] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
 
     // No management action applies to a retired player, regardless of
     // which club last held their contract.
@@ -221,14 +222,18 @@ export default function PlayerProfileActionsMenu({
     }
 
     return (
-        <ContextMenu ref={menuRef} items={items}>
+        <ContextMenu ref={menuRef} items={items} onOpenChange={setMenuOpen}>
             <Button
                 size="sm"
                 variant="outline"
                 onClick={(event) => {
+                    event.stopPropagation();
                     const rect = event.currentTarget.getBoundingClientRect();
                     menuRef.current?.open(rect.left, rect.bottom + 4);
                 }}
+                aria-label={t("common.playerActions", { name: player.match_name })}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
             >
                 {t("common.actions")}
                 <ChevronDown className="w-4 h-4 ml-1" />

--- a/src/components/players/PlayersListTab.test.tsx
+++ b/src/components/players/PlayersListTab.test.tsx
@@ -455,12 +455,12 @@ describe("PlayersListTab", () => {
     expect(playerRow).not.toBeNull();
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Scout" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Scout" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("send_scout", {
@@ -497,7 +497,7 @@ describe("PlayersListTab", () => {
       expect(playerRow).not.toBeNull();
 
       fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-      fireEvent.click(screen.getByRole("button", { name: "Scout" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Scout" }));
 
       await waitFor(() => {
         expect(screen.getByRole("alert")).toHaveTextContent(
@@ -560,7 +560,7 @@ describe("PlayersListTab", () => {
     expect(playerRow).not.toBeNull();
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Make Transfer Bid" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Make Transfer Bid" }));
 
     expect(screen.getByText("Make Transfer Bid")).toBeInTheDocument();
 

--- a/src/components/schedule/ScheduleTab.test.tsx
+++ b/src/components/schedule/ScheduleTab.test.tsx
@@ -254,7 +254,7 @@ describe("ScheduleTab", () => {
     });
 
     fireEvent.contextMenu(screen.getByTestId("schedule-fixture-fix-1"));
-    fireEvent.click(screen.getByRole("button", { name: /View team: Beta FC/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /View team: Beta FC/i }));
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
   });
 

--- a/src/components/scouting/ScoutingAssignmentsList.test.tsx
+++ b/src/components/scouting/ScoutingAssignmentsList.test.tsx
@@ -203,7 +203,7 @@ describe("ScoutingAssignmentsList", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("scouting-assignment-assignment-1"));
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
   });

--- a/src/components/scouting/ScoutingPlayerSearchCard.test.tsx
+++ b/src/components/scouting/ScoutingPlayerSearchCard.test.tsx
@@ -185,11 +185,11 @@ describe("ScoutingPlayerSearchCard", () => {
     expect(playerRow).not.toBeNull();
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "View team" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team" }));
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "View profile" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View profile" }));
     expect(onSelectPlayer).toHaveBeenCalledWith("player-1");
   });
 });

--- a/src/components/scouting/ScoutingTab.test.tsx
+++ b/src/components/scouting/ScoutingTab.test.tsx
@@ -507,7 +507,7 @@ describe("ScoutingTab", () => {
     expect(playerRow).not.toBeNull();
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Make Transfer Bid" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Make Transfer Bid" }));
 
     expect(screen.getByText("Make Transfer Bid")).toBeInTheDocument();
 

--- a/src/components/squad/SquadRosterView.tsx
+++ b/src/components/squad/SquadRosterView.tsx
@@ -112,6 +112,7 @@ export default function SquadRosterView({
     null,
   );
   const menuRefs = useRef<Map<string, ContextMenuHandle>>(new Map());
+  const [openMenuPlayerId, setOpenMenuPlayerId] = useState<string | null>(null);
 
   const posOrder: Record<string, number> = {
     Goalkeeper: 1,
@@ -782,6 +783,12 @@ export default function SquadRosterView({
                       if (handle) menuRefs.current.set(player.id, handle);
                       else menuRefs.current.delete(player.id);
                     }}
+                    onOpenChange={(open) => {
+                      setOpenMenuPlayerId((prev) => {
+                        if (open) return player.id;
+                        return prev === player.id ? null : prev;
+                      });
+                    }}
                   >
                     <tr
                       onClick={() => onSelectPlayer(player.id)}
@@ -906,7 +913,10 @@ export default function SquadRosterView({
                             const rect = e.currentTarget.getBoundingClientRect();
                             menuRefs.current.get(player.id)?.open(rect.left, rect.bottom + 4);
                           }}
-                          className="relative rounded-md p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+                          aria-label={t("common.playerActions", { name: player.match_name })}
+                          aria-haspopup="menu"
+                          aria-expanded={openMenuPlayerId === player.id}
+                          className="relative rounded-md p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition-colors"
                         >
                           <MoreVertical className="h-4 w-4" />
                           {hasUrgentItems && (

--- a/src/components/squad/SquadTab.test.tsx
+++ b/src/components/squad/SquadTab.test.tsx
@@ -344,10 +344,10 @@ describe("SquadTab", () => {
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Renew Contract" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Renew Contract" })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Renew Contract" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Renew Contract" }));
 
     expect(onSelectPlayer).toHaveBeenCalledWith("gk1", {
       openRenewal: true,
@@ -365,7 +365,7 @@ describe("SquadTab", () => {
     expect(playerRow).not.toBeNull();
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
 
-    fireEvent.click(screen.getByRole("button", { name: "Let Expire" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Let Expire" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("set_contract_exit_intent", {
@@ -376,7 +376,7 @@ describe("SquadTab", () => {
     });
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Terminate Now" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Terminate Now" }));
 
     expect(onSelectPlayer).toHaveBeenCalledWith("gk1", {
       openTermination: true,
@@ -398,7 +398,7 @@ describe("SquadTab", () => {
     const playerRow = screen.getByText("Player gk1").closest("tr");
     expect(playerRow).not.toBeNull();
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Add to Loan List" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add to Loan List" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("toggle_loan_list", {
@@ -435,7 +435,7 @@ describe("SquadTab", () => {
     const playerRow = screen.getByText("Player gk1").closest("tr");
     expect(playerRow).not.toBeNull();
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Reopen Talks" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Reopen Talks" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("clear_contract_exit_intent", {
@@ -465,7 +465,7 @@ describe("SquadTab", () => {
     expect(playerRow).not.toBeNull();
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
     fireEvent.click(
-      screen.getByRole("button", { name: "Delegate to youth academy" }),
+      screen.getByRole("menuitem", { name: "Delegate to youth academy" }),
     );
 
     await waitFor(() => {
@@ -505,7 +505,7 @@ describe("SquadTab", () => {
     const benchRow = screen.getByText("Player d5").closest("tr");
     expect(benchRow).not.toBeNull();
     fireEvent.contextMenu(benchRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "squad.makeStarter" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "squad.makeStarter" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("set_starting_xi", {

--- a/src/components/staff/StaffTab.test.tsx
+++ b/src/components/staff/StaffTab.test.tsx
@@ -216,7 +216,7 @@ describe("StaffTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /Available 1/i }));
     fireEvent.contextMenu(screen.getByTestId("staff-card-staff-2"));
     fireEvent.click(
-      within(screen.getByRole("menu")).getByRole("button", { name: "Hire staff" }),
+      within(screen.getByRole("menu")).getByRole("menuitem", { name: "Hire staff" }),
     );
 
     await waitFor(() => {
@@ -241,7 +241,7 @@ describe("StaffTab", () => {
     });
     fireEvent.contextMenu(screen.getByTestId("staff-card-staff-1"));
     fireEvent.click(
-      within(screen.getByRole("menu")).getByRole("button", { name: "Release staff" }),
+      within(screen.getByRole("menu")).getByRole("menuitem", { name: "Release staff" }),
     );
 
     await waitFor(() => {

--- a/src/components/tactics/TacticsTab.test.tsx
+++ b/src/components/tactics/TacticsTab.test.tsx
@@ -955,7 +955,7 @@ describe("TacticsTab", () => {
     const benchRow = screen.getByTestId("bench-player-d5");
     fireEvent.contextMenu(benchRow);
     fireEvent.click(
-      screen.getByRole("button", { name: "tactics.promoteToLineup" }),
+      screen.getByRole("menuitem", { name: "tactics.promoteToLineup" }),
     );
 
     await waitFor(() => {
@@ -988,7 +988,7 @@ describe("TacticsTab", () => {
 
     fireEvent.contextMenu(screen.getByTestId("pitch-player-d1"));
     fireEvent.click(
-      screen.getByRole("button", { name: "tactics.moveToBench" }),
+      screen.getByRole("menuitem", { name: "tactics.moveToBench" }),
     );
 
     await waitFor(() => {
@@ -1021,7 +1021,7 @@ describe("TacticsTab", () => {
 
     fireEvent.contextMenu(screen.getByTestId("xi-player-d1"));
     fireEvent.click(
-      screen.getByRole("button", { name: "tactics.makeCaptain" }),
+      screen.getByRole("menuitem", { name: "tactics.makeCaptain" }),
     );
 
     await waitFor(() => {
@@ -1044,7 +1044,7 @@ describe("TacticsTab", () => {
 
     fireEvent.contextMenu(screen.getByTestId("pitch-player-d1"));
     fireEvent.click(
-      screen.getByRole("button", { name: "tactics.makeCaptain" }),
+      screen.getByRole("menuitem", { name: "tactics.makeCaptain" }),
     );
 
     await waitFor(() => {

--- a/src/components/teamProfile/TeamProfile.test.tsx
+++ b/src/components/teamProfile/TeamProfile.test.tsx
@@ -350,7 +350,7 @@ describe("TeamProfile", () => {
     });
 
     fireEvent.contextMenu(screen.getByTestId("team-profile-roster-player-1"));
-    fireEvent.click(screen.getByRole("button", { name: "View profile" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View profile" }));
 
     expect(onSelectPlayer).toHaveBeenCalledWith("player-1");
   });

--- a/src/components/tournaments/TournamentsTab.test.tsx
+++ b/src/components/tournaments/TournamentsTab.test.tsx
@@ -276,7 +276,7 @@ describe("TournamentsTab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
     fireEvent.contextMenu(screen.getByTestId("tournaments-fixture-fixture-1"));
-    fireEvent.click(screen.getByRole("button", { name: "View team: Beta FC" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View team: Beta FC" }));
 
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
   });
@@ -293,7 +293,7 @@ describe("TournamentsTab", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("tournaments-top-scorer-player-1"));
-    fireEvent.click(screen.getByRole("button", { name: "View profile" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View profile" }));
 
     expect(onSelectPlayer).toHaveBeenCalledWith("player-1");
   });

--- a/src/components/transfers/TransfersTab.test.tsx
+++ b/src/components/transfers/TransfersTab.test.tsx
@@ -746,7 +746,7 @@ describe("TransfersTab", function (): void {
       expect(playerRow).not.toBeNull();
 
       fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-      fireEvent.click(screen.getByRole("button", { name: "Scout" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Scout" }));
 
       await waitFor(() => {
         expect(screen.getByRole("alert")).toHaveTextContent(
@@ -1599,7 +1599,7 @@ describe("TransfersTab", function (): void {
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
     fireEvent.click(
-      screen.getByRole("button", { name: "Remove from transfer list" }),
+      screen.getByRole("menuitem", { name: "Remove from transfer list" }),
     );
 
     await waitFor(function (): void {
@@ -1635,7 +1635,7 @@ describe("TransfersTab", function (): void {
     expect(playerRow).not.toBeNull();
 
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Add to loan list" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add to loan list" }));
 
     await waitFor(function (): void {
       expect(screen.getByRole("alert")).toHaveTextContent(

--- a/src/components/youthAcademy/YouthAcademyTab.test.tsx
+++ b/src/components/youthAcademy/YouthAcademyTab.test.tsx
@@ -401,7 +401,7 @@ describe("YouthAcademyTab", () => {
       expect(screen.getByText("Rising Star")).toBeInTheDocument();
     });
     fireEvent.contextMenu(screen.getByText("Rising Star").closest("tr") as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Promote to senior squad" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Promote to senior squad" }));
 
     await waitFor(() => {
       expect(screen.getByText("No youth players")).toBeInTheDocument();
@@ -435,7 +435,7 @@ describe("YouthAcademyTab", () => {
     const playerRow = screen.getByText("Rising Star").closest("tr");
     expect(playerRow).not.toBeNull();
     fireEvent.contextMenu(playerRow as HTMLTableRowElement);
-    fireEvent.click(screen.getByRole("button", { name: "Promote to senior squad" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Promote to senior squad" }));
 
     await waitFor(() => {
       expect(mockedInvoke).toHaveBeenCalledWith("set_player_squad_role", { playerId: "player-young", squadRole: "Senior" });

--- a/src/components/youthAcademy/YouthAcademyTab.tsx
+++ b/src/components/youthAcademy/YouthAcademyTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { GameStateData } from "../../store/gameStore";
 import { useGameStore } from "../../store/gameStore";
 import { useFetchedSquad } from "../../hooks/useFetchedSquad";
@@ -19,7 +19,7 @@ import { TraitList } from "../TraitBadge";
 import { useTranslation } from "react-i18next";
 import { countryName } from "../../lib/countries";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
-import ContextMenu from "../ContextMenu";
+import ContextMenu, { type ContextMenuHandle } from "../ContextMenu";
 import { buildPromoteToSeniorSquadMenuItem, buildViewProfileMenuItem } from "../playerActions/playerContextMenuItems";
 import { setPlayerSquadRole } from "../../services/squadService";
 import {
@@ -27,7 +27,7 @@ import {
   reassignYouthScouting,
   startYouthScouting,
 } from "../../services/scoutingService";
-import { GraduationCap, ScanSearch, TrendingUp, Star, Users, Sparkles } from "lucide-react";
+import { GraduationCap, ScanSearch, TrendingUp, Star, Users, Sparkles, MoreVertical } from "lucide-react";
 import type { DashboardNavigateContext } from "../dashboard/dashboardProfileNavigation";
 import type { PlayerSquadRole } from "../../store/types";
 import { calculateAvailableScouts } from "../scouting/ScoutingTab.helpers";
@@ -70,6 +70,8 @@ export default function YouthAcademyTab({
   const [youthTargetPosition, setYouthTargetPosition] = useState("");
   const [startingYouthSearch, setStartingYouthSearch] = useState(false);
   const [youthSearchError, setYouthSearchError] = useState<string | null>(null);
+  const menuRefs = useRef<Map<string, ContextMenuHandle>>(new Map());
+  const [openMenuPlayerId, setOpenMenuPlayerId] = useState<string | null>(null);
 
   const teamId = sessionState?.manager?.team_id ?? gameState?.manager?.team_id ?? null;
   const clockDate = sessionState?.clock.current_date ?? gameState?.clock.current_date ?? "";
@@ -456,6 +458,9 @@ export default function YouthAcademyTab({
                   <th className="py-3 px-4 font-heading font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 text-center">
                     {t("youthAcademy.condition")}
                   </th>
+                  <th className="py-3 px-4 w-10">
+                    <span className="sr-only">{t("common.actions")}</span>
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100 dark:divide-navy-600">
@@ -470,7 +475,20 @@ export default function YouthAcademyTab({
                   ];
 
                   return (
-                    <ContextMenu items={contextItems} key={player.id}>
+                    <ContextMenu
+                      items={contextItems}
+                      key={player.id}
+                      ref={(handle) => {
+                        if (handle) menuRefs.current.set(player.id, handle);
+                        else menuRefs.current.delete(player.id);
+                      }}
+                      onOpenChange={(open) => {
+                        setOpenMenuPlayerId((prev) => {
+                          if (open) return player.id;
+                          return prev === player.id ? null : prev;
+                        });
+                      }}
+                    >
                       <tr
                         onClick={() => onSelectPlayer?.(player.id)}
                         className="hover:bg-gray-50 dark:hover:bg-navy-700/50 cursor-pointer transition-colors"
@@ -565,6 +583,22 @@ export default function YouthAcademyTab({
                           >
                             {player.condition}%
                           </span>
+                        </td>
+                        <td className="py-2.5 px-4" onClick={(e) => e.stopPropagation()}>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              menuRefs.current.get(player.id)?.open(rect.left, rect.bottom + 4);
+                            }}
+                            aria-label={t("common.playerActions", { name: player.match_name })}
+                            aria-haspopup="menu"
+                            aria-expanded={openMenuPlayerId === player.id}
+                            className="rounded-md p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition-colors"
+                          >
+                            <MoreVertical className="h-4 w-4" />
+                          </button>
                         </td>
                       </tr>
                     </ContextMenu>

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -454,6 +454,7 @@
     "viewTeam": "Zobrazit tým",
     "player": "Hráč",
     "actions": "Akce",
+    "playerActions": "Akce hráče {{name}}",
     "position": "Pozice",
     "nationality": "Národnost",
     "contract": "Smlouva",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -450,6 +450,7 @@
     "viewTeam": "Team ansehen",
     "player": "Spieler",
     "actions": "Aktionen",
+    "playerActions": "Aktionen für {{name}}",
     "position": "Position",
     "nationality": "Nationalität",
     "contract": "Vertrag",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -454,6 +454,7 @@
     "viewTeam": "View team",
     "player": "Player",
     "actions": "Actions",
+    "playerActions": "Player actions for {{name}}",
     "position": "Position",
     "nationality": "Nationality",
     "contract": "Contract",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -480,6 +480,7 @@
     "viewTeam": "Ver equipo",
     "player": "Jugador",
     "actions": "Acciones",
+    "playerActions": "Acciones para {{name}}",
     "position": "Posición",
     "nationality": "Nacionalidad",
     "contract": "Contrato",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -450,6 +450,7 @@
     "viewTeam": "Voir l'équipe",
     "player": "Joueur",
     "actions": "Actions",
+    "playerActions": "Actions pour {{name}}",
     "position": "Poste",
     "nationality": "Nationalité",
     "contract": "Contrat",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -469,6 +469,7 @@
     "viewTeam": "Vedi squadra",
     "player": "Giocatore",
     "actions": "Azioni",
+    "playerActions": "Azioni per {{name}}",
     "position": "Posizione",
     "nationality": "Nazionalità",
     "contract": "Contratto",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -450,6 +450,7 @@
     "viewTeam": "Ver time",
     "player": "Jogador",
     "actions": "Ações",
+    "playerActions": "Ações para {{name}}",
     "position": "Posição",
     "nationality": "Nacionalidade",
     "contract": "Contrato",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -450,6 +450,7 @@
     "viewTeam": "Ver equipa",
     "player": "Jogador",
     "actions": "Ações",
+    "playerActions": "Ações para {{name}}",
     "position": "Posição",
     "nationality": "Nacionalidade",
     "contract": "Contrato",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -450,6 +450,7 @@
     "viewTeam": "Открыть команду",
     "player": "Игрок",
     "actions": "Действия",
+    "playerActions": "Действия игрока {{name}}",
     "position": "Позиция",
     "nationality": "Национальность",
     "contract": "Контракт",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -454,6 +454,7 @@
     "viewTeam": "Takımı görüntüle",
     "player": "Oyuncu",
     "actions": "İşlemler",
+    "playerActions": "{{name}} için oyuncu işlemleri",
     "position": "Pozisyon",
     "nationality": "Uyruk",
     "contract": "Sözleşme",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -450,6 +450,7 @@
     "viewTeam": "查看球队",
     "player": "球员",
     "actions": "操作",
+    "playerActions": "{{name}} 的球员操作",
     "position": "位置",
     "nationality": "国籍",
     "contract": "合同",


### PR DESCRIPTION
## Summary

Fixes #311 (Adika Bernard's Discord report).

- **Squad roster 3-dot trigger** — announced as "Player actions for {name}, menu button", `aria-haspopup="menu"`, `aria-expanded` follows the open state, `focus-visible` ring for keyboard users.
- **Youth academy** — added a visible 3-dot trigger column. The promote-to-senior action was previously only reachable via right-click, which is invisible to keyboard and screen-reader users.
- **ContextMenu** — items now expose `role="menuitem"` so a screen reader announces them as belonging to the menu (the container already had `role="menu"`). Escape closes the menu. New `onOpenChange` callback lets the trigger button drive `aria-expanded`.
- **Player profile Actions button** — same aria wiring, plus `event.stopPropagation()` on `onClick`. Without it the opening click bubbled to `window`, hit the just-installed close listener, and slammed the menu shut — which is why the button only appeared to respond to right-click.
- **i18n** — new `common.playerActions` key added to all 10 supported locales.

## Test plan

- [x] `npx vitest run` — 1070 passing, 0 failing.
- [x] `npx tsc --noEmit` — clean.
- [ ] Keyboard-tab to a squad row's 3-dot button — screen reader announces "Player actions for {name}, menu button, collapsed".
- [ ] Activate with Enter/Space — menu opens; each item announces as "menuitem"; Escape closes.
- [ ] Repeat in the youth academy view.
- [ ] Left-click the Actions button on a player profile — menu opens and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controlled open/close behavior for context menus, including improved ARIA and per-row menu state tracking in player-related screens.
  * Enhanced the youth academy player table with a dedicated “player actions” column and per-player menus.
* **Bug Fixes**
  * Context menus now close more reliably on selection and Escape, with focus restored after closing and consistent cross-menu dismissal.
* **Localization**
  * Added `common.playerActions` translation across supported languages.
* **Tests**
  * Updated interaction tests to select context-menu actions via `menuitem` roles and accessible names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->