### PR TITLE
fix(dashboard): don't resurface future-dated items in every day's digest (#321)

### DIFF
--- a/src/components/dashboard/advanceRecap.test.ts
+++ b/src/components/dashboard/advanceRecap.test.ts
@@ -327,4 +327,101 @@ describe("advanceRecap", function (): void {
     expect(recap.transfers).toEqual([]);
     expect(recap.hasEvents).toBe(false);
   });
+
+  it("surfaces news, inbox, and transfers on the day their date is reached", function (): void {
+    // Positive counterpart to the regression above: same fixture shape, but
+    // this time the clock has advanced to the event day, so each channel
+    // should populate exactly once and hasEvents should flip to true.
+    const eventDay = "2026-11-14";
+    const game = createGame({
+      clock: {
+        current_date: `${eventDay}T00:00:00Z`,
+        start_date: "2026-07-01T00:00:00Z",
+      },
+      news: [
+        {
+          id: "wc-kickoff",
+          headline: "World Cup 2026 kicks off",
+          body: "",
+          date: eventDay,
+          category: "Editorial",
+          team_ids: [],
+          player_ids: [],
+          read: false,
+        },
+      ],
+      messages: [
+        {
+          id: "future-brief",
+          subject: "Board briefing",
+          body: "",
+          sender: "",
+          sender_role: "",
+          date: eventDay,
+          read: false,
+          category: "Board",
+          priority: "High",
+          actions: [],
+        },
+      ],
+      competitions: [
+        {
+          id: "comp-1",
+          name: "Premier League",
+          season: 1,
+          participant_ids: ["team-1", "team-2"],
+          fixtures: [],
+          standings: [],
+          transfer_log: [
+            {
+              date: eventDay,
+              from_team_id: "team-1",
+              to_team_id: "team-2",
+              player_id: "player-1",
+              fee: 1,
+            },
+          ],
+        },
+      ],
+      league: null,
+    } as unknown as Partial<GameStateData>);
+
+    const recap = buildAdvanceRecap(game, eventDay, []);
+
+    expect(recap.news).toHaveLength(1);
+    expect(recap.inbox).toHaveLength(1);
+    expect(recap.transfers).toHaveLength(1);
+    expect(recap.hasEvents).toBe(true);
+  });
+
+  it("normalises ISO-timestamp sinceDate against calendar-day entries", function (): void {
+    // Guard against a regression where sinceDate arrives as a full ISO string
+    // (e.g. "2026-11-14T09:15:00Z") and the recap-window check ends up
+    // comparing timestamp-vs-date lexicographically. Entries dated the same
+    // calendar day must still be included.
+    const eventDay = "2026-11-14";
+    const game = createGame({
+      clock: {
+        current_date: `${eventDay}T23:59:00Z`,
+        start_date: "2026-07-01T00:00:00Z",
+      },
+      news: [
+        {
+          id: "same-day",
+          headline: "Same-day news",
+          body: "",
+          date: eventDay,
+          category: "Editorial",
+          team_ids: [],
+          player_ids: [],
+          read: false,
+        },
+      ],
+      league: null,
+    } as unknown as Partial<GameStateData>);
+
+    const recap = buildAdvanceRecap(game, `${eventDay}T09:15:00Z`, []);
+
+    expect(recap.news).toHaveLength(1);
+  });
 });

--- a/src/components/dashboard/advanceRecap.test.ts
+++ b/src/components/dashboard/advanceRecap.test.ts
@@ -266,4 +266,65 @@ describe("advanceRecap", function (): void {
     expect(recap.matches).toHaveLength(1);
     expect(recap.hasEvents).toBe(true);
   });
+
+  it("hides future-dated news, inbox, and transfers until their day", function (): void {
+    // Regression for #321: some articles (e.g. World Cup kickoff) are dated at
+    // the event day but created earlier. Without an upper bound they resurface
+    // in every digest day until their date arrives.
+    const game = createGame({
+      news: [
+        {
+          id: "wc-kickoff",
+          headline: "World Cup 2026 kicks off",
+          body: "",
+          date: "2026-11-14",
+          category: "Editorial",
+          team_ids: [],
+          player_ids: [],
+          read: false,
+        },
+      ],
+      messages: [
+        {
+          id: "future-brief",
+          subject: "Board briefing",
+          body: "",
+          sender: "",
+          sender_role: "",
+          date: "2026-11-14",
+          read: false,
+          category: "Board",
+          priority: "High",
+          actions: [],
+        },
+      ],
+      competitions: [
+        {
+          id: "comp-1",
+          name: "Premier League",
+          season: 1,
+          participant_ids: ["team-1", "team-2"],
+          fixtures: [],
+          standings: [],
+          transfer_log: [
+            {
+              date: "2026-11-14",
+              from_team_id: "team-1",
+              to_team_id: "team-2",
+              player_id: "player-1",
+              fee: 1,
+            },
+          ],
+        },
+      ],
+      league: null,
+    } as unknown as Partial<GameStateData>);
+
+    const recap = buildAdvanceRecap(game, "2026-07-01", []);
+
+    expect(recap.news).toEqual([]);
+    expect(recap.inbox).toEqual([]);
+    expect(recap.transfers).toEqual([]);
+    expect(recap.hasEvents).toBe(false);
+  });
 });

--- a/src/components/dashboard/advanceRecap.ts
+++ b/src/components/dashboard/advanceRecap.ts
@@ -81,6 +81,10 @@ export function buildAdvanceRecap(
   matches: AdvanceMatchResultData[],
 ): AdvanceRecap {
   const advancedTo = toDatePart(game.clock?.current_date);
+  // Callers pass the pre-advance clock, which can be a full ISO timestamp;
+  // normalise it to the same YYYY-MM-DD granularity as articleDay so the
+  // window check compares like-for-like (see recap test #321).
+  const sinceDay = toDatePart(sinceDate);
   const userTeamId = game.manager?.team_id ?? null;
 
   const teamName = new Map((game.teams ?? []).map((team) => [team.id, team.name]));
@@ -107,7 +111,7 @@ export function buildAdvanceRecap(
   // opens next month) don't resurface in every day's digest until they arrive.
   const inRecapWindow = (date: string): boolean => {
     const day = articleDay(date);
-    return day >= sinceDate && day <= advancedTo;
+    return day >= sinceDay && day <= advancedTo;
   };
 
   const userCompetition = getUserCompetition(game);

--- a/src/components/dashboard/advanceRecap.ts
+++ b/src/components/dashboard/advanceRecap.ts
@@ -1,6 +1,7 @@
 import type { AdvanceMatchResultData } from "../../services/advanceTimeService";
 import type { GameStateData } from "../../store/gameStore";
 import { getUserCompetition } from "../../lib/fixtures";
+import { articleDay } from "../../utils/newsVisibility";
 
 /** Match result enriched with the user's outcome (win/draw/loss) when they were involved. */
 export interface RecapMatch extends AdvanceMatchResultData {
@@ -101,9 +102,17 @@ export function buildAdvanceRecap(
     return { ...match, userResult };
   });
 
+  // Cap items at the current game date so future-dated entries (e.g. a World
+  // Cup kickoff article dated at the kickoff day, or a transfer window that
+  // opens next month) don't resurface in every day's digest until they arrive.
+  const inRecapWindow = (date: string): boolean => {
+    const day = articleDay(date);
+    return day >= sinceDate && day <= advancedTo;
+  };
+
   const userCompetition = getUserCompetition(game);
   const transfers: RecapTransfer[] = (userCompetition?.transfer_log ?? [])
-    .filter((entry) => entry.date >= sinceDate)
+    .filter((entry) => inRecapWindow(entry.date))
     .sort((left, right) => right.date.localeCompare(left.date))
     .slice(0, MAX_PER_SECTION)
     .map((entry) => ({
@@ -119,7 +128,7 @@ export function buildAdvanceRecap(
   const news: RecapHeadline[] = (game.news ?? [])
     .filter(
       (article) =>
-        article.date >= sinceDate &&
+        inRecapWindow(article.date) &&
         !isRoutineRecapNews(article),
     )
     .sort((left, right) => right.date.localeCompare(left.date))
@@ -133,7 +142,7 @@ export function buildAdvanceRecap(
     }));
 
   const inbox: RecapHeadline[] = (game.messages ?? [])
-    .filter((message) => message.date >= sinceDate && message.priority === "High")
+    .filter((message) => inRecapWindow(message.date) && message.priority === "High")
     .sort((left, right) => right.date.localeCompare(left.date))
     .slice(0, MAX_PER_SECTION)
     .map((message) => ({


### PR DESCRIPTION
## Summary

Fixes #321.

`buildAdvanceRecap` filters `news`, high-priority `messages`, and the competition `transfer_log` by `date >= sinceDate` — but there was no upper bound. An article dated at a future event (e.g. the **World Cup {{year}} kicks off** headline, dated at the kickoff day but created at the season rollover months earlier) matched every advance and repeated in every digest day until its date arrived. The News tab already hides these via `utils/newsVisibility.isNewsArticleVisible`; apply the same day-based rule here.

- Extract a local `inRecapWindow(date)` predicate that clamps to `[sinceDate, advancedTo]` using `articleDay(...)`. Uses day-part comparison so mixed formats (`YYYY-MM-DD` vs RFC3339) sort correctly.
- Same fix incidentally covers the qualifying-campaign announcement and any other future-dated inbox message or transfer entry — all three sections went through separate but identical `>= sinceDate` filters.

## Test plan

- [x] `npx vitest run src/components/dashboard/advanceRecap` — 9 passing (added a regression test asserting future-dated news, inbox, and transfers are all excluded).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: southern-hemisphere save (Argentine Primera) rolling into a World Cup season; digest days between rollover and kickoff no longer repeat the kickoff headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Advance recap content is now restricted to the correct date range, capping news, inbox, and transfer updates up to the game’s current advance-to date to prevent future-dated items from appearing early.
  * Recaps now correctly treat `sinceDate` with time-of-day by matching on calendar day, ensuring eligible events are included and recap remains empty when nothing qualifies.
* **Tests**
  * Expanded coverage for advance recap date-bound inclusion/exclusion and ISO timestamp handling to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->