### PR TITLE
fix(a11y): soften saturated red text in transfer modals (#306)

### DIFF
--- a/src/components/transfers/FreeAgentContractModal.tsx
+++ b/src/components/transfers/FreeAgentContractModal.tsx
@@ -145,7 +145,7 @@ export function FreeAgentContractForm({
               })}
             </p>
             {!projection.policy_allows ? (
-              <p className="text-xs text-red-500">
+              <p className="text-xs text-red-600 dark:text-red-300">
                 {t("playerProfile.renewalBudgetWarning")}
               </p>
             ) : null}

--- a/src/components/transfers/LoanOfferModal.tsx
+++ b/src/components/transfers/LoanOfferModal.tsx
@@ -167,7 +167,7 @@ export function LoanOfferForm({
             })}
           </p>
         ) : (
-          <p role="alert" className="text-xs text-red-500 mb-3">
+          <p role="alert" className="text-xs text-red-600 dark:text-red-300 mb-3">
             {t("transfers.noLoanPeriodAvailable")}
           </p>
         )}
@@ -272,7 +272,7 @@ export function LoanOfferForm({
 
         {result ? (
           <div
-            className={`text-xs font-heading font-bold uppercase tracking-wider mb-3 ${result === "accepted" ? "text-green-500" : result === "counter_offer" ? "text-amber-500" : "text-red-500"}`}
+            className={`text-xs font-heading font-bold uppercase tracking-wider mb-3 ${result === "accepted" ? "text-green-500" : result === "counter_offer" ? "text-amber-500" : "text-red-600 dark:text-red-300"}`}
           >
             {result === "accepted"
               ? acceptedMessage ?? t(acceptedLabelKey)
@@ -303,7 +303,7 @@ export function LoanOfferForm({
         ) : null}
 
         {error && !result ? (
-          <p role="alert" className="text-xs text-red-500 mb-3">
+          <p role="alert" className="text-xs text-red-600 dark:text-red-300 mb-3">
             {error}
           </p>
         ) : null}

--- a/src/components/transfers/TransferBidModal.tsx
+++ b/src/components/transfers/TransferBidModal.tsx
@@ -152,12 +152,12 @@ export function TransferBidForm({
             })}
           </p>
           {bidProjection.exceeds_transfer_budget ? (
-            <p className="text-xs text-red-500">
+            <p className="text-xs text-red-600 dark:text-red-300">
               {t("transfers.bidImpactOverTransferBudget")}
             </p>
           ) : null}
           {bidProjection.exceeds_finance ? (
-            <p className="text-xs text-red-500">
+            <p className="text-xs text-red-600 dark:text-red-300">
               {t("transfers.bidImpactOverBalance")}
             </p>
           ) : null}
@@ -174,7 +174,7 @@ export function TransferBidForm({
       <TransferNegotiationHistory offer={activeBidOffer} mode="outgoing" />
       {bidResult ? (
         <div
-          className={`text-xs font-heading font-bold uppercase tracking-wider mb-3 ${bidResult === "accepted" ? "text-green-500" : bidResult === "rejected" ? "text-red-500" : "text-amber-500"}`}
+          className={`text-xs font-heading font-bold uppercase tracking-wider mb-3 ${bidResult === "accepted" ? "text-green-500" : bidResult === "rejected" ? "text-red-600 dark:text-red-300" : "text-amber-500"}`}
         >
           {bidResult === "accepted"
             ? t("transfers.bidAccepted")


### PR DESCRIPTION
## Summary

Fixes #306 (tactical scope).

Inline warnings and rejection labels in the three transfer modals used bare \`text-red-500\` (#ef4444). Fully saturated red on dark navy is the worst-case combination for chromatic aberration on RGB sub-pixel displays — the text visibly smears for readers with mild astigmatism.

Swap to the existing \`text-red-600 dark:text-red-300\` pattern already in use (see \`PlayerDealWorkspace.tsx:266\`) — deeper red in light mode, lighter/less-saturated red in dark mode.

- \`TransferBidModal.tsx\` — 3 sites (over-transfer-budget/over-balance warnings + the \"BID REJECTED\" status)
- \`FreeAgentContractModal.tsx\` — 1 site (renewal budget warning)
- \`LoanOfferModal.tsx\` — 3 sites (loan-period unavailable, rejection status, error banner)

The strategic app-wide sweep (~95 remaining \`text-red-500\` sites, extract \`<ErrorBanner>\` / \`<ErrorInline>\`) is out of scope — it lives in its own follow-up per the issue.

## Test plan

- [x] \`npx vitest run src/components/transfers\` — 58 passing
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: submit a bid that exceeds transfer budget → warning is readable in dark mode without chromatic-aberration smear
- [ ] Manual: get a bid rejected → \"BID REJECTED\" status readable
- [ ] Manual: light mode still shows clearly-red text (deeper red-600 instead of the previous red-500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated warning, error, and rejection text to use a slightly darker red tone across transfer-related dialogs.
  * Improved consistency of alert styling in budget, loan, and bid feedback messages, including dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->