### PR TITLE
fix(profile): surface every engine attribute; drive display from a single source of truth

### DIFF
--- a/src/components/playerProfile/PlayerAttributeRadarChart.tsx
+++ b/src/components/playerProfile/PlayerAttributeRadarChart.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Radar,
   RadarChart,
@@ -8,10 +9,14 @@ import {
 } from "recharts";
 import { useChartTheme } from "../ui/charts/chartTheme";
 import { ChartContainer } from "../ui/charts/ChartContainer";
-import type { PlayerAttributeGroup } from "./PlayerProfile.attributes";
+import type { PlayerData } from "../../store/gameStore";
+import {
+  getPlayerAttributeEntry,
+  type PlayerAttributeKey,
+} from "./PlayerProfile.attributes";
 
 interface PlayerAttributeRadarChartProps {
-  attrGroups: PlayerAttributeGroup[];
+  player: PlayerData;
   isGk: boolean;
 }
 
@@ -21,56 +26,50 @@ interface RadarEntry {
   fullMark: number;
 }
 
-function pickOutfieldAttrs(groups: PlayerAttributeGroup[]): RadarEntry[] {
-  // Build by picking from groups[0]=physical, groups[1]=technical, groups[2]=mental
-  const physGroup = groups[0]?.attrs ?? [];
-  const techGroup = groups[1]?.attrs ?? [];
-  const mentGroup = groups[2]?.attrs ?? [];
+// Fixed radar picks per player type — kept as attribute keys, not positional
+// indices, so reordering the profile's attribute groups can't silently change
+// what the radar shows.
+const OUTFIELD_RADAR_KEYS: readonly PlayerAttributeKey[] = [
+  "pace",
+  "shooting",
+  "passing",
+  "dribbling",
+  "tackling",
+  "vision",
+  "teamwork",
+  "stamina",
+];
 
-  const selected = [
-    physGroup[0], // pace
-    techGroup[1], // shooting
-    techGroup[0], // passing
-    techGroup[3], // dribbling
-    techGroup[2], // tackling
-    mentGroup[1], // vision
-    mentGroup[5], // teamwork
-    physGroup[1], // stamina
-  ].filter(Boolean) as { name: string; value: number }[];
+const GK_RADAR_KEYS: readonly PlayerAttributeKey[] = [
+  "handling",
+  "reflexes",
+  "aerial",
+  "composure",
+  "vision",
+  "teamwork",
+  "stamina",
+  "strength",
+];
 
-  return selected.map((a) => ({ attr: a.name, value: a.value, fullMark: 100 }));
-}
-
-function pickGkAttrs(groups: PlayerAttributeGroup[]): RadarEntry[] {
-  const gkGroup = groups.find((_, i) => i === 3)?.attrs ?? groups[groups.length - 1]?.attrs ?? [];
-  const mentGroup = groups[2]?.attrs ?? [];
-  const physGroup = groups[0]?.attrs ?? [];
-
-  const selected = [
-    gkGroup[0], // handling
-    gkGroup[1], // reflexes
-    gkGroup[2], // aerial
-    mentGroup[3], // composure
-    mentGroup[1], // vision
-    mentGroup[5], // teamwork
-    physGroup[1], // stamina
-    physGroup[2], // strength
-  ].filter(Boolean) as { name: string; value: number }[];
-
-  return selected.map((a) => ({ attr: a.name, value: a.value, fullMark: 100 }));
+function buildRadarData(
+  player: PlayerData,
+  keys: readonly PlayerAttributeKey[],
+  translate: (key: string) => string,
+): RadarEntry[] {
+  return keys.map((key) => {
+    const entry = getPlayerAttributeEntry(player, key, translate);
+    return { attr: entry.name, value: entry.value, fullMark: 100 };
+  });
 }
 
 export function PlayerAttributeRadarChart({
-  attrGroups,
+  player,
   isGk,
 }: PlayerAttributeRadarChartProps) {
+  const { t } = useTranslation();
   const theme = useChartTheme();
 
-  if (attrGroups.length === 0) {
-    return <ChartContainer isEmpty height={240} />;
-  }
-
-  const data = isGk ? pickGkAttrs(attrGroups) : pickOutfieldAttrs(attrGroups);
+  const data = buildRadarData(player, isGk ? GK_RADAR_KEYS : OUTFIELD_RADAR_KEYS, t);
 
   if (data.length === 0) {
     return <ChartContainer isEmpty height={240} />;

--- a/src/components/playerProfile/PlayerProfile.attributes.test.ts
+++ b/src/components/playerProfile/PlayerProfile.attributes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { PlayerData } from "../../store/gameStore";
-import { buildPlayerAttributeGroups } from "./PlayerProfile.attributes";
+import {
+    buildPlayerAttributeGroups,
+    getPlayerAttributeEntry,
+} from "./PlayerProfile.attributes";
 
 function createPlayer(overrides: Partial<PlayerData> = {}): PlayerData {
     return {
@@ -62,7 +65,7 @@ function createPlayer(overrides: Partial<PlayerData> = {}): PlayerData {
 }
 
 describe("PlayerProfile.attributes", () => {
-    it("builds the standard outfield attribute groups with averages", () => {
+    it("builds the standard outfield groups with aerial in Physical", () => {
         const groups = buildPlayerAttributeGroups(createPlayer(), (key) => key);
 
         expect(groups.map((group) => group.label)).toEqual([
@@ -70,21 +73,50 @@ describe("PlayerProfile.attributes", () => {
             "common.attrGroups.technical",
             "common.attrGroups.mental",
         ]);
-        expect(groups[0]?.attrs).toHaveLength(4);
-        expect(groups[0]?.average).toBe(62);
-        expect(groups[1]?.attrs).toHaveLength(5);
+
+        // Physical includes aerial for every player — the engine uses it for
+        // every header duel, not just GK claims.
+        expect(groups[0]?.attrs.map((attr) => attr.name)).toEqual([
+            "common.attributes.pace",
+            "common.attributes.stamina",
+            "common.attributes.strength",
+            "common.attributes.agility",
+            "common.attributes.aerial",
+        ]);
+        expect(groups[0]?.average).toBe(65);
+
+        expect(groups[1]?.attrs.map((attr) => attr.name)).toEqual([
+            "common.attributes.passing",
+            "common.attributes.shooting",
+            "common.attributes.tackling",
+            "common.attributes.dribbling",
+            "common.attributes.defending",
+        ]);
         expect(groups[1]?.average).toBe(66);
-        expect(groups[2]?.attrs).toHaveLength(7);
+
+        expect(groups[2]?.attrs.map((attr) => attr.name)).toEqual([
+            "common.attributes.positioning",
+            "common.attributes.vision",
+            "common.attributes.decisions",
+            "common.attributes.composure",
+            "common.attributes.aggression",
+            "common.attributes.teamwork",
+            "common.attributes.leadership",
+        ]);
         expect(groups[2]?.average).toBe(72);
     });
 
-    it("adds the goalkeeper-specific group for goalkeepers", () => {
+    it("adds a goalkeeper-only group with handling and reflexes for goalkeepers", () => {
         const groups = buildPlayerAttributeGroups(
             createPlayer({ position: "Goalkeeper", natural_position: "Goalkeeper" }),
             (key) => key,
         );
 
         expect(groups).toHaveLength(4);
+        // Aerial still lives in Physical for goalkeepers — not duplicated.
+        expect(groups[0]?.attrs.map((attr) => attr.name)).toContain(
+            "common.attributes.aerial",
+        );
         expect(groups[3]).toMatchObject({
             label: "common.attrGroups.goalkeeper",
             average: 77,
@@ -92,7 +124,59 @@ describe("PlayerProfile.attributes", () => {
         expect(groups[3]?.attrs.map((attr) => attr.name)).toEqual([
             "common.attributes.handling",
             "common.attributes.reflexes",
-            "common.attributes.aerial",
         ]);
+    });
+
+    // Guards against the class of bug this file was refactored to fix: an
+    // attribute added to the engine PlayerAttributes struct but forgotten in
+    // the profile display. If a new key appears in `player.attributes`, this
+    // test fails until it's grouped into the meta table above.
+    it("surfaces every engine attribute in exactly one group for outfielders and one-or-two groups for goalkeepers", () => {
+        const outfielderGroups = buildPlayerAttributeGroups(
+            createPlayer(),
+            (key) => key,
+        );
+        const gkGroups = buildPlayerAttributeGroups(
+            createPlayer({ position: "Goalkeeper", natural_position: "Goalkeeper" }),
+            (key) => key,
+        );
+
+        const player = createPlayer();
+        const allAttributeKeys = Object.keys(
+            player.attributes,
+        ) as (keyof PlayerData["attributes"])[];
+
+        for (const key of allAttributeKeys) {
+            const expectedName = `common.attributes.${key}`;
+
+            const gkAppearances = gkGroups
+                .flatMap((group) => group.attrs)
+                .filter((attr) => attr.name === expectedName).length;
+            expect(gkAppearances, `${key} on GK profile`).toBe(1);
+
+            // Handling and reflexes are gated to the goalkeeper group; every
+            // other attribute must also appear for outfielders.
+            const isGoalkeeperOnly = key === "handling" || key === "reflexes";
+            const outfielderAppearances = outfielderGroups
+                .flatMap((group) => group.attrs)
+                .filter((attr) => attr.name === expectedName).length;
+            expect(
+                outfielderAppearances,
+                `${key} on outfielder profile`,
+            ).toBe(isGoalkeeperOnly ? 0 : 1);
+        }
+    });
+
+    it("looks up a single attribute by key without positional indexing", () => {
+        const player = createPlayer();
+
+        expect(getPlayerAttributeEntry(player, "aerial", (key) => key)).toEqual({
+            name: "common.attributes.aerial",
+            value: 78,
+        });
+        expect(getPlayerAttributeEntry(player, "pace", (key) => key)).toEqual({
+            name: "common.attributes.pace",
+            value: 60,
+        });
     });
 });

--- a/src/components/playerProfile/PlayerProfile.attributes.ts
+++ b/src/components/playerProfile/PlayerProfile.attributes.ts
@@ -13,6 +13,62 @@ export interface PlayerAttributeGroup {
     average: number;
 }
 
+export type PlayerAttributeKey = keyof PlayerData["attributes"];
+type AttributeGroupKey = "physical" | "technical" | "mental" | "goalkeeper";
+
+// Single source of truth for the profile display. Every attribute in
+// PlayerData["attributes"] must appear here — `satisfies Record<...>` makes
+// adding an attribute to the domain a compile-time error until it's grouped.
+// Order within each group follows insertion order below (ES2015+ guarantees
+// `Object.entries` returns keys in insertion order for string keys).
+const ATTRIBUTE_META = {
+    // Physical
+    pace: "physical",
+    stamina: "physical",
+    strength: "physical",
+    agility: "physical",
+    // Aerial belongs with Physical — engine uses it for header duels for every
+    // player, not just GK claims (see engine/resolution.rs & zone_resolution.rs).
+    aerial: "physical",
+
+    // Technical
+    passing: "technical",
+    shooting: "technical",
+    tackling: "technical",
+    dribbling: "technical",
+    defending: "technical",
+
+    // Mental
+    positioning: "mental",
+    vision: "mental",
+    decisions: "mental",
+    composure: "mental",
+    aggression: "mental",
+    teamwork: "mental",
+    leadership: "mental",
+
+    // Goalkeeper — only used in save/penalty/zone resolution for GKs. Hidden
+    // for outfielders to keep the profile focused on stats that apply.
+    handling: "goalkeeper",
+    reflexes: "goalkeeper",
+} as const satisfies Record<PlayerAttributeKey, AttributeGroupKey>;
+
+const GROUP_LABEL_KEY: Record<AttributeGroupKey, string> = {
+    physical: "common.attrGroups.physical",
+    technical: "common.attrGroups.technical",
+    mental: "common.attrGroups.mental",
+    goalkeeper: "common.attrGroups.goalkeeper",
+};
+
+// Fixed display order for groups. Groups not applicable to the current player
+// (e.g. `goalkeeper` for outfielders) are filtered downstream.
+const GROUP_ORDER: readonly AttributeGroupKey[] = [
+    "physical",
+    "technical",
+    "mental",
+    "goalkeeper",
+];
+
 function createAttributeGroup(
     label: string,
     attrs: PlayerAttributeEntry[],
@@ -26,98 +82,56 @@ function createAttributeGroup(
     };
 }
 
+function isGroupApplicable(
+    group: AttributeGroupKey,
+    player: PlayerData,
+): boolean {
+    if (group === "goalkeeper") {
+        return player.position === "Goalkeeper";
+    }
+    return true;
+}
+
 export function buildPlayerAttributeGroups(
     player: PlayerData,
     translate: TranslateFn,
 ): PlayerAttributeGroup[] {
-    const groups: PlayerAttributeGroup[] = [
-        createAttributeGroup(translate("common.attrGroups.physical"), [
-            { name: translate("common.attributes.pace"), value: player.attributes.pace },
-            {
-                name: translate("common.attributes.stamina"),
-                value: player.attributes.stamina,
-            },
-            {
-                name: translate("common.attributes.strength"),
-                value: player.attributes.strength,
-            },
-            {
-                name: translate("common.attributes.agility"),
-                value: player.attributes.agility,
-            },
-        ]),
-        createAttributeGroup(translate("common.attrGroups.technical"), [
-            {
-                name: translate("common.attributes.passing"),
-                value: player.attributes.passing,
-            },
-            {
-                name: translate("common.attributes.shooting"),
-                value: player.attributes.shooting,
-            },
-            {
-                name: translate("common.attributes.tackling"),
-                value: player.attributes.tackling,
-            },
-            {
-                name: translate("common.attributes.dribbling"),
-                value: player.attributes.dribbling,
-            },
-            {
-                name: translate("common.attributes.defending"),
-                value: player.attributes.defending,
-            },
-        ]),
-        createAttributeGroup(translate("common.attrGroups.mental"), [
-            {
-                name: translate("common.attributes.positioning"),
-                value: player.attributes.positioning,
-            },
-            {
-                name: translate("common.attributes.vision"),
-                value: player.attributes.vision,
-            },
-            {
-                name: translate("common.attributes.decisions"),
-                value: player.attributes.decisions,
-            },
-            {
-                name: translate("common.attributes.composure"),
-                value: player.attributes.composure,
-            },
-            {
-                name: translate("common.attributes.aggression"),
-                value: player.attributes.aggression,
-            },
-            {
-                name: translate("common.attributes.teamwork"),
-                value: player.attributes.teamwork,
-            },
-            {
-                name: translate("common.attributes.leadership"),
-                value: player.attributes.leadership,
-            },
-        ]),
-    ];
-
-    if (player.position === "Goalkeeper") {
-        groups.push(
-            createAttributeGroup(translate("common.attrGroups.goalkeeper"), [
-                {
-                    name: translate("common.attributes.handling"),
-                    value: player.attributes.handling,
-                },
-                {
-                    name: translate("common.attributes.reflexes"),
-                    value: player.attributes.reflexes,
-                },
-                {
-                    name: translate("common.attributes.aerial"),
-                    value: player.attributes.aerial,
-                },
-            ]),
-        );
+    const buckets = new Map<AttributeGroupKey, PlayerAttributeEntry[]>();
+    for (const [attributeKey, groupKey] of Object.entries(ATTRIBUTE_META) as [
+        PlayerAttributeKey,
+        AttributeGroupKey,
+    ][]) {
+        const bucket = buckets.get(groupKey) ?? [];
+        bucket.push({
+            name: translate(`common.attributes.${attributeKey}`),
+            value: player.attributes[attributeKey],
+        });
+        buckets.set(groupKey, bucket);
     }
 
-    return groups;
+    return GROUP_ORDER
+        .filter((group) => isGroupApplicable(group, player))
+        .map((groupKey) => {
+            const attrs = buckets.get(groupKey) ?? [];
+            return createAttributeGroup(translate(GROUP_LABEL_KEY[groupKey]), attrs);
+        })
+        .filter((group) => group.attrs.length > 0);
+}
+
+/**
+ * Look up a single attribute entry (translated name + value) by its key,
+ * without relying on positional indexing into `PlayerAttributeGroup.attrs`.
+ * Callers that need a specific attribute (e.g. the radar chart picking a
+ * subset for visualisation) should use this instead of `group.attrs[i]` so
+ * reordering `ATTRIBUTE_META` above doesn't silently swap what they render.
+ */
+export function getPlayerAttributeEntry(
+    player: PlayerData,
+    key: PlayerAttributeKey,
+    translate: TranslateFn,
+): PlayerAttributeEntry {
+    return {
+        name: translate(`common.attributes.${key}`),
+        value: player.attributes[key],
+    };
 }

--- a/src/components/playerProfile/PlayerProfile.attributes.ts
+++ b/src/components/playerProfile/PlayerProfile.attributes.ts
@@ -82,12 +82,20 @@ function createAttributeGroup(
     };
 }
 
+// Shared with PlayerProfile.tsx / the radar chart so attribute grouping and
+// radar keys agree on who is a goalkeeper. Prefers natural_position (same as
+// primaryPosition in PlayerProfile) so temporary re-deployments don't hide GK
+// attributes from a natural keeper's card.
+export function isGoalkeeper(player: PlayerData): boolean {
+    return (player.natural_position || player.position) === "Goalkeeper";
+}
+
 function isGroupApplicable(
     group: AttributeGroupKey,
     player: PlayerData,
 ): boolean {
     if (group === "goalkeeper") {
-        return player.position === "Goalkeeper";
+        return isGoalkeeper(player);
     }
     return true;
 }

--- a/src/components/playerProfile/PlayerProfile.tsx
+++ b/src/components/playerProfile/PlayerProfile.tsx
@@ -834,6 +834,7 @@ export default function PlayerProfile({
 
         <PlayerProfileAttributesCard
           attrGroups={attrGroups}
+          player={player}
           isOwnClub={isManagerSquadProfile}
           isGk={primaryPosition === "Goalkeeper"}
           title={t("playerProfile.attributes")}

--- a/src/components/playerProfile/PlayerProfile.tsx
+++ b/src/components/playerProfile/PlayerProfile.tsx
@@ -31,7 +31,7 @@ import {
   type PlayerAdvancedStatsSummary,
 } from "./PlayerProfile.helpers";
 import PlayerProfileAdvancedStatsCard from "./PlayerProfileAdvancedStatsCard";
-import { buildPlayerAttributeGroups } from "./PlayerProfile.attributes";
+import { buildPlayerAttributeGroups, isGoalkeeper } from "./PlayerProfile.attributes";
 import PlayerProfileAttributesCard from "./PlayerProfileAttributesCard";
 import PlayerProfileCareerHistoryCard from "./PlayerProfileCareerHistoryCard";
 import PlayerProfileContractCard from "./PlayerProfileContractCard";
@@ -836,7 +836,7 @@ export default function PlayerProfile({
           attrGroups={attrGroups}
           player={player}
           isOwnClub={isManagerSquadProfile}
-          isGk={primaryPosition === "Goalkeeper"}
+          isGk={isGoalkeeper(player)}
           title={t("playerProfile.attributes")}
           averageLabel={t("common.average")}
           hiddenTitle={t("playerProfile.attributesHidden")}

--- a/src/components/playerProfile/PlayerProfileAttributesCard.tsx
+++ b/src/components/playerProfile/PlayerProfileAttributesCard.tsx
@@ -3,6 +3,7 @@ import { Shield } from "lucide-react";
 import { getAttributeColorClass } from "./PlayerProfile.helpers";
 import { getAttributeColors } from "../../lib/playerAttributeDisplay";
 import type { PlayerAttributeGroup } from "./PlayerProfile.attributes";
+import type { PlayerData } from "../../store/gameStore";
 import { Card, CardBody, CardHeader, ProgressBar } from "../ui";
 import { PlayerAttributeRadarChart } from "./PlayerAttributeRadarChart";
 import PlayerProfileStatCard from "./PlayerProfileStatCard";
@@ -19,6 +20,7 @@ function placeholderWidth(name: string): number {
 
 interface PlayerProfileAttributesCardProps {
     attrGroups: PlayerAttributeGroup[];
+    player: PlayerData;
     isOwnClub: boolean;
     isGk?: boolean;
     title: string;
@@ -31,6 +33,7 @@ interface PlayerProfileAttributesCardProps {
 
 export default function PlayerProfileAttributesCard({
     attrGroups,
+    player,
     isOwnClub,
     isGk = false,
     title,
@@ -72,7 +75,7 @@ export default function PlayerProfileAttributesCard({
             </CardHeader>
             <CardBody>
                 {isOwnClub && view === "radar" ? (
-                    <PlayerAttributeRadarChart attrGroups={attrGroups} isGk={isGk} />
+                    <PlayerAttributeRadarChart player={player} isGk={isGk} />
                 ) : isOwnClub ? (
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:auto-rows-fr">
                         {attrGroups.map((group) => (


### PR DESCRIPTION
## Summary

The player profile hid `aerial` from every outfielder — the value only appeared inside the goalkeeper-only group. But the engine uses aerial for **every header duel**, both attacker and defender (`engine/resolution.rs`, `zone_resolution.rs`) — so a striker or centre-back with 90 aerial looked identical to one with 20 on the profile.

Root cause was a fully hand-written attribute → group mapping in \`buildPlayerAttributeGroups\`. Easy to forget an attribute when the domain grows. Replaced with a single \`ATTRIBUTE_META\` table constrained by \`satisfies Record<PlayerAttributeKey, AttributeGroupKey>\` — adding an attribute to \`PlayerData[\"attributes\"]\` is now a compile-time error until it's grouped.

## Changes

- \`aerial\` moves into the **Physical** group for everyone (belongs with jumping/heading; still weighted 14/100 in a GK's OVR).
- \`handling\` / \`reflexes\` stay in the **Goalkeeper** group and remain hidden for outfielders — grep confirms they're only read in save/penalty/zone-resolution logic.
- \`PlayerAttributeRadarChart\` no longer picks by positional index into group arrays. A new \`getPlayerAttributeEntry(player, key, translate)\` helper resolves by attribute key, so reordering groups can't silently swap what the radar renders.
- \`PlayerProfileAttributesCard\` now takes \`player\` alongside \`attrGroups\` (needed to pass through to the radar).

## Test plan

- [x] \`npx vitest run\` — 1072 passing (added a coverage test that iterates every key of \`PlayerData[\"attributes\"]\` and asserts each surfaces exactly once — with the two GK-only exceptions for outfielders)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open an outfielder's profile → Physical group has 5 rows including aerial; no Goalkeeper group
- [ ] Manual: open a goalkeeper's profile → Physical has aerial once, Goalkeeper group has handling + reflexes only
- [ ] Manual: switch to the radar view for both — aerial appears for a GK; outfielder chart unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Player attribute radar charts now build from player data directly, with deterministic outfield vs goalkeeper configuration.
  * Attribute labels in the radar view are now translated consistently.

* **Bug Fixes**
  * Corrected attribute grouping so stats are placed in the right section without duplication (including the aerial/physical vs goalkeeper handling).
  * Improved “empty” radar chart behavior when no attribute data is available.

* **Tests**
  * Updated and expanded tests to validate attribute grouping, goalkeeper/outfield distribution, and translated radar entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->