### PR TITLE
feat(transfers): click the OVR header to sort the transfer list

### DIFF
--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -188,6 +188,12 @@ export default function TransfersTab({
   // filter output before pagination so sorted rows stay stable across pages.
   const [ovrSortDir, setOvrSortDir] = useState<"none" | "desc" | "asc">("none");
   const [marketPage, setMarketPage] = useState(1);
+  const cycleOvrSort = () => {
+    setOvrSortDir((current) =>
+      current === "none" ? "desc" : current === "desc" ? "asc" : "none",
+    );
+    setMarketPage(1);
+  };
   const [counterTarget, setCounterTarget] = useState<CounterTarget | null>(
     null,
   );
@@ -780,10 +786,12 @@ export default function TransfersTab({
       return filtered;
     }
 
-    const sorted = [...filtered].sort(
-      (left, right) => getPlayerOvr(left) - getPlayerOvr(right),
+    // Direction encoded in the comparator (rather than sort().reverse()) so
+    // tied players keep the same relative order in both asc and desc.
+    const factor = ovrSortDir === "desc" ? -1 : 1;
+    return [...filtered].sort(
+      (left, right) => factor * (getPlayerOvr(left) - getPlayerOvr(right)),
     );
-    return ovrSortDir === "desc" ? sorted.reverse() : sorted;
   }, [
     affordableOnly,
     availabilityFilter,
@@ -1339,7 +1347,6 @@ export default function TransfersTab({
                       {t("common.wage")}
                     </th>
                     <th
-                      role="columnheader"
                       aria-sort={
                         ovrSortDir === "desc"
                           ? "descending"
@@ -1347,18 +1354,14 @@ export default function TransfersTab({
                             ? "ascending"
                             : "none"
                       }
-                      className={`py-3 px-4 font-heading font-bold uppercase tracking-wider cursor-pointer select-none hover:text-primary-400 transition-colors ${ovrSortDir !== "none" ? "text-primary-500 dark:text-primary-400" : "text-gray-500 dark:text-gray-400"}`}
-                      onClick={() => {
-                        // Cycle: none → desc → asc → none. Reset paging on any change so
-                        // the user always lands on the first page of the new order.
-                        setOvrSortDir((current) =>
-                          current === "none"
-                            ? "desc"
-                            : current === "desc"
-                              ? "asc"
-                              : "none",
-                        );
-                        setMarketPage(1);
+                      tabIndex={0}
+                      className={`py-3 px-4 font-heading font-bold uppercase tracking-wider cursor-pointer select-none hover:text-primary-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 transition-colors ${ovrSortDir !== "none" ? "text-primary-500 dark:text-primary-400" : "text-gray-500 dark:text-gray-400"}`}
+                      onClick={cycleOvrSort}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          cycleOvrSort();
+                        }
                       }}
                     >
                       <div className="flex items-center gap-1">

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -21,6 +21,8 @@ import {
   UserPlus,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
 import {
   getTeamName,
@@ -182,6 +184,9 @@ export default function TransfersTab({
   );
   const positionFilterRef = useRef<HTMLDivElement | null>(null);
   const [affordableOnly, setAffordableOnly] = useState(false);
+  // Click the OVR header to cycle: none → desc → asc → none. Applied over the
+  // filter output before pagination so sorted rows stay stable across pages.
+  const [ovrSortDir, setOvrSortDir] = useState<"none" | "desc" | "asc">("none");
   const [marketPage, setMarketPage] = useState(1);
   const [counterTarget, setCounterTarget] = useState<CounterTarget | null>(
     null,
@@ -756,31 +761,39 @@ export default function TransfersTab({
     () => getCurrentTransferList(view, transferCollections),
     [transferCollections, view],
   );
-  const filteredList = useMemo(
-    () =>
-      filterTransferPlayers(
-        currentList,
-        search,
-        null,
-        isPlayersView ? availabilityFilter : "all",
-        isPlayersView && affordableOnly && myTeam
-          ? {
-              transferBudget: myTeam.transfer_budget,
-              finance: myTeam.finance,
-            }
-          : null,
-        specificPositions,
-      ),
-    [
-      affordableOnly,
-      availabilityFilter,
+  const filteredList = useMemo(() => {
+    const filtered = filterTransferPlayers(
       currentList,
-      isPlayersView,
-      myTeam,
       search,
+      null,
+      isPlayersView ? availabilityFilter : "all",
+      isPlayersView && affordableOnly && myTeam
+        ? {
+            transferBudget: myTeam.transfer_budget,
+            finance: myTeam.finance,
+          }
+        : null,
       specificPositions,
-    ],
-  );
+    );
+
+    if (ovrSortDir === "none") {
+      return filtered;
+    }
+
+    const sorted = [...filtered].sort(
+      (left, right) => getPlayerOvr(left) - getPlayerOvr(right),
+    );
+    return ovrSortDir === "desc" ? sorted.reverse() : sorted;
+  }, [
+    affordableOnly,
+    availabilityFilter,
+    currentList,
+    isPlayersView,
+    myTeam,
+    ovrSortDir,
+    search,
+    specificPositions,
+  ]);
   const marketTotalPages = Math.max(
     1,
     Math.ceil(filteredList.length / TRANSFER_MARKET_PAGE_SIZE),
@@ -1325,8 +1338,37 @@ export default function TransfersTab({
                     <th className="py-3 px-4 font-heading font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
                       {t("common.wage")}
                     </th>
-                    <th className="py-3 px-4 font-heading font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                      {t("common.ovr")}
+                    <th
+                      role="columnheader"
+                      aria-sort={
+                        ovrSortDir === "desc"
+                          ? "descending"
+                          : ovrSortDir === "asc"
+                            ? "ascending"
+                            : "none"
+                      }
+                      className={`py-3 px-4 font-heading font-bold uppercase tracking-wider cursor-pointer select-none hover:text-primary-400 transition-colors ${ovrSortDir !== "none" ? "text-primary-500 dark:text-primary-400" : "text-gray-500 dark:text-gray-400"}`}
+                      onClick={() => {
+                        // Cycle: none → desc → asc → none. Reset paging on any change so
+                        // the user always lands on the first page of the new order.
+                        setOvrSortDir((current) =>
+                          current === "none"
+                            ? "desc"
+                            : current === "desc"
+                              ? "asc"
+                              : "none",
+                        );
+                        setMarketPage(1);
+                      }}
+                    >
+                      <div className="flex items-center gap-1">
+                        {t("common.ovr")}
+                        {ovrSortDir === "desc" ? (
+                          <ChevronDown className="w-3 h-3" />
+                        ) : ovrSortDir === "asc" ? (
+                          <ChevronUp className="w-3 h-3" />
+                        ) : null}
+                      </div>
                     </th>
                     <th className="py-3 px-4 font-heading font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
                       {t("common.status")}


### PR DESCRIPTION
## Summary

Adds click-to-sort on the OVR column in the market / transfer list. Cycles **none → desc → asc → none**, resets pagination on every change so the user always lands on the first page of the new order, and shows a chevron affordance beside the header text.

## Details

- New \`ovrSortDir\` state: \`\"none\" | \"desc\" | \"asc\"\`.
- Sort runs over \`filteredList\` **before pagination**, so ordering is stable across pages and composes cleanly with the existing filters (affordable-only, availability, position).
- Header gets \`role=\"columnheader\"\` and \`aria-sort\` reflecting the current direction.
- Only OVR is sortable for now — the rest of the columns stay in insertion order. Extending to name / age / value / wage is straightforward if that's wanted next.

## Test plan

- [x] \`npx vitest run src/components/transfers\` — 58 passing
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open the transfer market → click OVR → rows sort high → low; click again → low → high; click again → back to insertion order
- [ ] Manual: paginate then sort → land on page 1 of the sorted list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OVR-based sorting to the Transfers table.
  * Users can click the OVR column to cycle through no sort, descending, and ascending order.
  * Sorting is applied before pagination to keep ordering consistent across pages.

* **Bug Fixes**
  * Reset the current page when the sort direction changes to prevent mismatched results.
  * Improved accessibility by updating sort indicators and enabling keyboard interaction for the sortable header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->