### PR TITLE
fix: credit transfer_budget when selling player

### DIFF
--- a/src-tauri/crates/ofm_core/src/transfers.rs
+++ b/src-tauri/crates/ofm_core/src/transfers.rs
@@ -3445,9 +3445,11 @@ fn execute_transfer(
         }
     }
 
-    // Credit selling team
+    // Credit selling team. Sales replenish the current-season transfer envelope;
+    // end-of-season still recalculates next season's budget from finance.
     if let Some(t) = game.teams.iter_mut().find(|t| t.id == from_team_id) {
         t.finance += fee as i64;
+        t.transfer_budget += fee as i64;
         // Remove from starting XI
         if let Some(pos) = t.starting_xi_ids.iter().position(|id| id == player_id) {
             t.starting_xi_ids.remove(pos);

--- a/src-tauri/crates/ofm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/transfers_tests.rs
@@ -435,6 +435,54 @@ fn accepted_closed_window_incoming_transfer_is_registered_when_the_window_opens(
             && entry.to_team_id.as_deref() == Some("team-2")
             && entry.fee == Some(1_400_000)
     }));
+
+    let seller = game.teams.iter().find(|team| team.id == "team-1").unwrap();
+    assert_eq!(seller.finance, 6_400_000);
+    assert_eq!(seller.transfer_budget, 3_400_000);
+    let buyer = game.teams.iter().find(|team| team.id == "team-2").unwrap();
+    assert_eq!(buyer.finance, 1_600_000);
+    assert_eq!(buyer.transfer_budget, 1_600_000);
+}
+
+#[test]
+fn accepted_incoming_transfer_credits_selling_team_transfer_budget() {
+    let fee = 1_568_520;
+    let starting_finance = 5_000_000;
+    let starting_budget = 116_000;
+    let buyer_starting_finance = 8_000_000;
+    let buyer_starting_budget = 3_000_000;
+
+    let mut player = make_user_player("player-sale-budget-credit");
+    player
+        .transfer_offers
+        .push(make_pending_incoming_offer("offer-sale-budget-credit", fee));
+    let mut game = make_game_with_player(player, vec![], starting_finance, starting_budget);
+    game.teams[1].finance = buyer_starting_finance;
+    game.teams[1].transfer_budget = buyer_starting_budget;
+
+    respond_to_offer(
+        &mut game,
+        "player-sale-budget-credit",
+        "offer-sale-budget-credit",
+        true,
+    )
+    .expect("accepted incoming transfer should execute immediately while the window is open");
+
+    let seller = game.teams.iter().find(|team| team.id == "team-1").unwrap();
+    assert_eq!(seller.finance, starting_finance + fee as i64);
+    assert_eq!(seller.transfer_budget, starting_budget + fee as i64);
+
+    let buyer = game.teams.iter().find(|team| team.id == "team-2").unwrap();
+    assert_eq!(buyer.finance, buyer_starting_finance - fee as i64);
+    assert_eq!(buyer.transfer_budget, buyer_starting_budget - fee as i64);
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "player-sale-budget-credit")
+        .unwrap();
+    assert_eq!(player.team_id.as_deref(), Some("team-2"));
+    assert_eq!(player.transfer_offers[0].status, TransferOfferStatus::Accepted);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Credit the selling team's `transfer_budget` when a permanent transfer completes.
- Keep the existing buyer-side `finance` and `transfer_budget` debit behavior unchanged.
- Keep end-of-season transfer budget recalculation unchanged.

## Tests

- `cargo test -p ofm_core --test transfers_tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer fees now correctly update both club finances and transfer budgets when a permanent transfer is completed.
  * Improved handling for transfers accepted while the transfer window status changes, ensuring funds and player moves are processed consistently.

* **Tests**
  * Added regression coverage for transfer budget and finance updates on completed transfers.
  * Added checks for immediate transfer acceptance and correct player assignment after the deal is finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->