### PR TITLE
fix(world-editor): accept all FIFA nationalities on import (#270)

### DIFF
--- a/src-tauri/crates/ofm_core/src/nations.rs
+++ b/src-tauri/crates/ofm_core/src/nations.rs
@@ -1,6 +1,16 @@
 //! Catalog of football nations the game can field internationally, beyond
 //! whatever nationalities a world's clubs happen to contain. Used to fill a
 //! World Cup field by synthesising national squads for missing nations.
+//!
+//! Two lists, kept deliberately separate:
+//! - [`NATION_CATALOG`] — the curated World Cup pool. Qualifying synthesises its
+//!   field from exactly these nations, so its size drives qualifying scale.
+//! - [`ADDITIONAL_NATIONS`] — the rest of the FIFA membership. Selectable in the
+//!   editor and accepted by the importer, but *not* World Cup entrants.
+//!
+//! [`all_nations`] is the union and the single source of truth for which
+//! nationalities are valid/selectable (see #270); the World Cup deliberately
+//! reads only `NATION_CATALOG`.
 
 pub struct NationDef {
     pub code: &'static str,
@@ -8,9 +18,11 @@ pub struct NationDef {
     pub region_id: &'static str,
 }
 
-/// Real football nations across every confederation, strongest footballing
-/// traditions first within each region (order is used as a soft seeding hint
-/// when squads are otherwise equal).
+/// The World Cup pool: real football nations across every confederation,
+/// strongest footballing traditions first within each region (order is used as
+/// a soft seeding hint when squads are otherwise equal). Qualifying builds its
+/// field from this list, so keep it curated — adding a nation here enters it
+/// into the World Cup. Merely-selectable nations belong in [`ADDITIONAL_NATIONS`].
 pub const NATION_CATALOG: &[NationDef] = &[
     // Europe
     NationDef { code: "FR", name: "France", region_id: "europe" },
@@ -88,8 +100,171 @@ pub const NATION_CATALOG: &[NationDef] = &[
     NationDef { code: "NZ", name: "New Zealand", region_id: "oceania" },
 ];
 
+/// The rest of the FIFA membership: real nations selectable in the world editor
+/// / manager creation and accepted by the package importer (see #270), but not
+/// part of the World Cup pool, so qualifying scale and balance are unchanged.
+/// Codes are ISO 3166-1 alpha-2 (the UK home nations live in [`NATION_CATALOG`]
+/// under football identities). Grouped by region for readability only.
+pub const ADDITIONAL_NATIONS: &[NationDef] = &[
+    // Europe (UEFA)
+    NationDef { code: "AL", name: "Albania", region_id: "europe" },
+    NationDef { code: "AD", name: "Andorra", region_id: "europe" },
+    NationDef { code: "AM", name: "Armenia", region_id: "europe" },
+    NationDef { code: "AZ", name: "Azerbaijan", region_id: "europe" },
+    NationDef { code: "BY", name: "Belarus", region_id: "europe" },
+    NationDef { code: "BA", name: "Bosnia and Herzegovina", region_id: "europe" },
+    NationDef { code: "BG", name: "Bulgaria", region_id: "europe" },
+    NationDef { code: "CY", name: "Cyprus", region_id: "europe" },
+    NationDef { code: "EE", name: "Estonia", region_id: "europe" },
+    NationDef { code: "FO", name: "Faroe Islands", region_id: "europe" },
+    NationDef { code: "FI", name: "Finland", region_id: "europe" },
+    NationDef { code: "GE", name: "Georgia", region_id: "europe" },
+    NationDef { code: "GI", name: "Gibraltar", region_id: "europe" },
+    NationDef { code: "IS", name: "Iceland", region_id: "europe" },
+    NationDef { code: "IL", name: "Israel", region_id: "europe" },
+    NationDef { code: "KZ", name: "Kazakhstan", region_id: "europe" },
+    NationDef { code: "XK", name: "Kosovo", region_id: "europe" },
+    NationDef { code: "LV", name: "Latvia", region_id: "europe" },
+    NationDef { code: "LI", name: "Liechtenstein", region_id: "europe" },
+    NationDef { code: "LT", name: "Lithuania", region_id: "europe" },
+    NationDef { code: "LU", name: "Luxembourg", region_id: "europe" },
+    NationDef { code: "MT", name: "Malta", region_id: "europe" },
+    NationDef { code: "MD", name: "Moldova", region_id: "europe" },
+    NationDef { code: "ME", name: "Montenegro", region_id: "europe" },
+    NationDef { code: "MK", name: "North Macedonia", region_id: "europe" },
+    NationDef { code: "SM", name: "San Marino", region_id: "europe" },
+    NationDef { code: "SK", name: "Slovakia", region_id: "europe" },
+    NationDef { code: "SI", name: "Slovenia", region_id: "europe" },
+    // Central America & Caribbean (CONCACAF)
+    NationDef { code: "BZ", name: "Belize", region_id: "central-america" },
+    NationDef { code: "NI", name: "Nicaragua", region_id: "central-america" },
+    NationDef { code: "CU", name: "Cuba", region_id: "central-america" },
+    NationDef { code: "HT", name: "Haiti", region_id: "central-america" },
+    NationDef { code: "TT", name: "Trinidad and Tobago", region_id: "central-america" },
+    NationDef { code: "DO", name: "Dominican Republic", region_id: "central-america" },
+    NationDef { code: "CW", name: "Curaçao", region_id: "central-america" },
+    NationDef { code: "GY", name: "Guyana", region_id: "central-america" },
+    NationDef { code: "SR", name: "Suriname", region_id: "central-america" },
+    NationDef { code: "BB", name: "Barbados", region_id: "central-america" },
+    NationDef { code: "AG", name: "Antigua and Barbuda", region_id: "central-america" },
+    NationDef { code: "GD", name: "Grenada", region_id: "central-america" },
+    NationDef { code: "KN", name: "Saint Kitts and Nevis", region_id: "central-america" },
+    NationDef { code: "LC", name: "Saint Lucia", region_id: "central-america" },
+    NationDef { code: "VC", name: "Saint Vincent and the Grenadines", region_id: "central-america" },
+    NationDef { code: "DM", name: "Dominica", region_id: "central-america" },
+    NationDef { code: "AW", name: "Aruba", region_id: "central-america" },
+    NationDef { code: "BS", name: "Bahamas", region_id: "central-america" },
+    NationDef { code: "BM", name: "Bermuda", region_id: "central-america" },
+    NationDef { code: "KY", name: "Cayman Islands", region_id: "central-america" },
+    NationDef { code: "PR", name: "Puerto Rico", region_id: "central-america" },
+    NationDef { code: "MS", name: "Montserrat", region_id: "central-america" },
+    NationDef { code: "VG", name: "British Virgin Islands", region_id: "central-america" },
+    NationDef { code: "VI", name: "U.S. Virgin Islands", region_id: "central-america" },
+    NationDef { code: "TC", name: "Turks and Caicos Islands", region_id: "central-america" },
+    NationDef { code: "AI", name: "Anguilla", region_id: "central-america" },
+    // Africa (CAF)
+    NationDef { code: "AO", name: "Angola", region_id: "africa" },
+    NationDef { code: "BJ", name: "Benin", region_id: "africa" },
+    NationDef { code: "BW", name: "Botswana", region_id: "africa" },
+    NationDef { code: "BF", name: "Burkina Faso", region_id: "africa" },
+    NationDef { code: "BI", name: "Burundi", region_id: "africa" },
+    NationDef { code: "CV", name: "Cape Verde", region_id: "africa" },
+    NationDef { code: "CF", name: "Central African Republic", region_id: "africa" },
+    NationDef { code: "TD", name: "Chad", region_id: "africa" },
+    NationDef { code: "KM", name: "Comoros", region_id: "africa" },
+    NationDef { code: "CG", name: "Congo", region_id: "africa" },
+    NationDef { code: "CD", name: "DR Congo", region_id: "africa" },
+    NationDef { code: "DJ", name: "Djibouti", region_id: "africa" },
+    NationDef { code: "GQ", name: "Equatorial Guinea", region_id: "africa" },
+    NationDef { code: "ER", name: "Eritrea", region_id: "africa" },
+    NationDef { code: "SZ", name: "Eswatini", region_id: "africa" },
+    NationDef { code: "ET", name: "Ethiopia", region_id: "africa" },
+    NationDef { code: "GA", name: "Gabon", region_id: "africa" },
+    NationDef { code: "GM", name: "Gambia", region_id: "africa" },
+    NationDef { code: "GN", name: "Guinea", region_id: "africa" },
+    NationDef { code: "GW", name: "Guinea-Bissau", region_id: "africa" },
+    NationDef { code: "KE", name: "Kenya", region_id: "africa" },
+    NationDef { code: "LS", name: "Lesotho", region_id: "africa" },
+    NationDef { code: "LR", name: "Liberia", region_id: "africa" },
+    NationDef { code: "LY", name: "Libya", region_id: "africa" },
+    NationDef { code: "MG", name: "Madagascar", region_id: "africa" },
+    NationDef { code: "MW", name: "Malawi", region_id: "africa" },
+    NationDef { code: "ML", name: "Mali", region_id: "africa" },
+    NationDef { code: "MR", name: "Mauritania", region_id: "africa" },
+    NationDef { code: "MU", name: "Mauritius", region_id: "africa" },
+    NationDef { code: "MZ", name: "Mozambique", region_id: "africa" },
+    NationDef { code: "NA", name: "Namibia", region_id: "africa" },
+    NationDef { code: "NE", name: "Niger", region_id: "africa" },
+    NationDef { code: "RW", name: "Rwanda", region_id: "africa" },
+    NationDef { code: "ST", name: "São Tomé and Príncipe", region_id: "africa" },
+    NationDef { code: "SC", name: "Seychelles", region_id: "africa" },
+    NationDef { code: "SL", name: "Sierra Leone", region_id: "africa" },
+    NationDef { code: "SO", name: "Somalia", region_id: "africa" },
+    NationDef { code: "SS", name: "South Sudan", region_id: "africa" },
+    NationDef { code: "SD", name: "Sudan", region_id: "africa" },
+    NationDef { code: "TZ", name: "Tanzania", region_id: "africa" },
+    NationDef { code: "TG", name: "Togo", region_id: "africa" },
+    NationDef { code: "UG", name: "Uganda", region_id: "africa" },
+    NationDef { code: "ZM", name: "Zambia", region_id: "africa" },
+    NationDef { code: "ZW", name: "Zimbabwe", region_id: "africa" },
+    // Asia (AFC)
+    NationDef { code: "AF", name: "Afghanistan", region_id: "asia" },
+    NationDef { code: "BH", name: "Bahrain", region_id: "asia" },
+    NationDef { code: "BD", name: "Bangladesh", region_id: "asia" },
+    NationDef { code: "BT", name: "Bhutan", region_id: "asia" },
+    NationDef { code: "BN", name: "Brunei", region_id: "asia" },
+    NationDef { code: "KH", name: "Cambodia", region_id: "asia" },
+    NationDef { code: "TW", name: "Chinese Taipei", region_id: "asia" },
+    NationDef { code: "GU", name: "Guam", region_id: "asia" },
+    NationDef { code: "HK", name: "Hong Kong", region_id: "asia" },
+    NationDef { code: "IN", name: "India", region_id: "asia" },
+    NationDef { code: "ID", name: "Indonesia", region_id: "asia" },
+    NationDef { code: "JO", name: "Jordan", region_id: "asia" },
+    NationDef { code: "KP", name: "North Korea", region_id: "asia" },
+    NationDef { code: "KW", name: "Kuwait", region_id: "asia" },
+    NationDef { code: "KG", name: "Kyrgyzstan", region_id: "asia" },
+    NationDef { code: "LA", name: "Laos", region_id: "asia" },
+    NationDef { code: "LB", name: "Lebanon", region_id: "asia" },
+    NationDef { code: "MO", name: "Macau", region_id: "asia" },
+    NationDef { code: "MY", name: "Malaysia", region_id: "asia" },
+    NationDef { code: "MV", name: "Maldives", region_id: "asia" },
+    NationDef { code: "MN", name: "Mongolia", region_id: "asia" },
+    NationDef { code: "MM", name: "Myanmar", region_id: "asia" },
+    NationDef { code: "NP", name: "Nepal", region_id: "asia" },
+    NationDef { code: "OM", name: "Oman", region_id: "asia" },
+    NationDef { code: "PK", name: "Pakistan", region_id: "asia" },
+    NationDef { code: "PS", name: "Palestine", region_id: "asia" },
+    NationDef { code: "PH", name: "Philippines", region_id: "asia" },
+    NationDef { code: "SG", name: "Singapore", region_id: "asia" },
+    NationDef { code: "LK", name: "Sri Lanka", region_id: "asia" },
+    NationDef { code: "SY", name: "Syria", region_id: "asia" },
+    NationDef { code: "TJ", name: "Tajikistan", region_id: "asia" },
+    NationDef { code: "TL", name: "Timor-Leste", region_id: "asia" },
+    NationDef { code: "TM", name: "Turkmenistan", region_id: "asia" },
+    NationDef { code: "VN", name: "Vietnam", region_id: "asia" },
+    NationDef { code: "YE", name: "Yemen", region_id: "asia" },
+    // Oceania (OFC)
+    NationDef { code: "FJ", name: "Fiji", region_id: "oceania" },
+    NationDef { code: "NC", name: "New Caledonia", region_id: "oceania" },
+    NationDef { code: "PG", name: "Papua New Guinea", region_id: "oceania" },
+    NationDef { code: "SB", name: "Solomon Islands", region_id: "oceania" },
+    NationDef { code: "PF", name: "Tahiti", region_id: "oceania" },
+    NationDef { code: "VU", name: "Vanuatu", region_id: "oceania" },
+    NationDef { code: "AS", name: "American Samoa", region_id: "oceania" },
+    NationDef { code: "CK", name: "Cook Islands", region_id: "oceania" },
+    NationDef { code: "WS", name: "Samoa", region_id: "oceania" },
+    NationDef { code: "TO", name: "Tonga", region_id: "oceania" },
+];
+
+/// Every nation the game recognises: the World Cup pool plus the wider FIFA
+/// membership. The single source of truth for selectable / importable
+/// nationalities — the World Cup deliberately reads only [`NATION_CATALOG`].
+pub fn all_nations() -> impl Iterator<Item = &'static NationDef> {
+    NATION_CATALOG.iter().chain(ADDITIONAL_NATIONS.iter())
+}
+
 pub fn nation_by_code(code: &str) -> Option<&'static NationDef> {
-    NATION_CATALOG.iter().find(|nation| nation.code == code)
+    all_nations().find(|nation| nation.code == code)
 }
 
 /// Confederation/region id for a nation code, defaulting to Europe for nations
@@ -159,17 +334,59 @@ mod tests {
     }
 
     #[test]
-    fn catalog_codes_are_unique() {
-        let mut codes: Vec<&str> = NATION_CATALOG.iter().map(|n| n.code).collect();
+    fn nation_codes_are_unique_across_both_lists() {
+        // A code appearing in both lists would double-count a nation and let a
+        // World Cup entrant masquerade as a merely-selectable one.
+        let mut codes: Vec<&str> = all_nations().map(|n| n.code).collect();
         codes.sort();
         let before = codes.len();
         codes.dedup();
-        assert_eq!(before, codes.len());
+        assert_eq!(before, codes.len(), "nation codes must be globally unique");
     }
 
     #[test]
     fn display_name_falls_back_to_the_code() {
         assert_eq!(nation_display_name("BR"), "Brazil");
         assert_eq!(nation_display_name("XX"), "XX");
+    }
+
+    #[test]
+    fn selectable_covers_previously_missing_fifa_nations() {
+        // Regression for #270: real FIFA nations selectable in the world editor
+        // that used to be rejected on import because they were absent entirely.
+        assert!(nation_by_code("AM").is_some(), "Armenia should be selectable");
+        assert!(
+            nation_by_code("GW").is_some(),
+            "Guinea-Bissau should be selectable"
+        );
+        // Antarctica is not a football nation and must not leak in.
+        assert!(nation_by_code("AQ").is_none(), "Antarctica must be excluded");
+        // The bare UK code is never used — the home nations stand in for it.
+        assert!(nation_by_code("GB").is_none(), "GB must not be used");
+    }
+
+    #[test]
+    fn additional_nations_are_not_world_cup_entrants() {
+        // The decoupling contract (see #270): widening who is selectable must
+        // not widen the World Cup pool, or qualifying scale/balance shifts.
+        for nation in ADDITIONAL_NATIONS {
+            assert!(
+                !NATION_CATALOG.iter().any(|c| c.code == nation.code),
+                "{} is in both lists; ADDITIONAL_NATIONS must stay out of the WC pool",
+                nation.code
+            );
+        }
+    }
+
+    #[test]
+    fn every_nation_has_a_known_region() {
+        for nation in all_nations() {
+            assert!(
+                is_builtin_region(nation.region_id),
+                "{} has region {} which no nation defines",
+                nation.code,
+                nation.region_id
+            );
+        }
     }
 }

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -28,9 +28,41 @@ fn load_world_data_from_path(world_source: &str) -> Result<ofm_core::generator::
 fn load_world_data_from_package(dir: &str) -> Result<ofm_core::generator::WorldData, String> {
     let (package, errors) = ofm_core::generator::load_world_package(std::path::Path::new(dir));
     if !errors.is_empty() {
-        return Err("be.error.package.invalid".to_string());
+        return Err(first_package_error_message(&errors));
     }
     ofm_core::generator::build_world_from_package(&package)
+}
+
+/// Surface the first concrete validation error (e.g. *which* country is unknown)
+/// rather than a generic "invalid package", so a failed import is diagnosable.
+/// Uses the `key?param=value` convention `resolveBackendError` understands (see
+/// `src/utils/backendI18n.ts`); the `country` param is localised frontend-side.
+fn first_package_error_message(errors: &[ofm_core::generator::PackageError]) -> String {
+    let Some(first) = errors.first() else {
+        return "be.error.package.invalid".to_string();
+    };
+    if first.params.is_empty() {
+        return first.code.clone();
+    }
+    let query = first
+        .params
+        .iter()
+        .map(|(key, value)| format!("{}={}", encode_error_param(key), encode_error_param(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{}?{}", first.code, query)
+}
+
+/// Minimal percent-encoding for error-message query params so the frontend's
+/// `URLSearchParams` parse stays intact for ids/names with reserved characters.
+fn encode_error_param(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => c.to_string(),
+            _ => c.to_string().bytes().map(|b| format!("%{b:02X}")).collect(),
+        })
+        .collect()
 }
 
 pub(crate) fn map_save_manager_lock_error<T>(
@@ -237,7 +269,7 @@ fn load_world_data_from_package_ids(
         let path = packages_dir.join(format!("{id}.ofm"));
         let (pkg, errors) = ofm_core::generator::load_world_package_from_ofm(&path);
         if !errors.is_empty() {
-            return Err("be.error.package.invalid".to_string());
+            return Err(first_package_error_message(&errors));
         }
         let version = pkg
             .meta
@@ -254,7 +286,7 @@ fn load_world_data_from_package_ids(
     }
     let (merged, errors) = ofm_core::generator::merge_world_packages(loaded);
     if !errors.is_empty() {
-        return Err("be.error.package.invalid".to_string());
+        return Err(first_package_error_message(&errors));
     }
     let world = ofm_core::generator::build_world_from_package(&merged)?;
     if world.teams.is_empty() {

--- a/src-tauri/src/commands/world.rs
+++ b/src-tauri/src/commands/world.rs
@@ -398,6 +398,30 @@ pub fn check_package_stack(
     Ok(conflicts)
 }
 
+/// A selectable football nation, mirrored from the backend `NATION_CATALOG`.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct NationInfo {
+    pub code: String,
+    pub name: String,
+    pub region: String,
+}
+
+/// Every nation the game recognises (World Cup pool + wider FIFA membership).
+/// This is the single source of truth for which nationalities are selectable in
+/// the world editor / manager creation, so the frontend never offers a nation
+/// the importer would reject (see #270). Codes match the frontend's ISO +
+/// football-identity handling.
+#[tauri::command]
+pub fn get_nations() -> Vec<NationInfo> {
+    ofm_core::nations::all_nations()
+        .map(|nation| NationInfo {
+            code: nation.code.to_string(),
+            name: nation.name.to_string(),
+            region: nation.region_id.to_string(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src-tauri/src/commands/world.rs
+++ b/src-tauri/src/commands/world.rs
@@ -398,7 +398,8 @@ pub fn check_package_stack(
     Ok(conflicts)
 }
 
-/// A selectable football nation, mirrored from the backend `NATION_CATALOG`.
+/// A selectable football nation, mirrored from the backend's combined nation
+/// catalog (`all_nations()` — World Cup pool + wider FIFA membership).
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct NationInfo {
     pub code: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,7 @@ pub fn run() {
             list_installed_packages,
             uninstall_package,
             check_package_stack,
+            get_nations,
             start_new_game,
             validate_competition_definitions,
             validate_world_package,

--- a/src/components/menu/CreateManagerNationalityField.tsx
+++ b/src/components/menu/CreateManagerNationalityField.tsx
@@ -34,8 +34,14 @@ async function loadCountryResources(): Promise<CountryResources> {
     countryResourcesPromise ??= Promise.all([
         import("../../lib/countries"),
         import("../ui/CountryFlag"),
-    ]).then(([countriesModule, flagModule]) => ({
-        allNationalities: countriesModule.allNationalities,
+        // The backend catalog is the source of truth for selectable
+        // nationalities (#270). If it can't be fetched, fall back to full ISO.
+        import("../../services/nationsService")
+            .then((m) => m.getNationCodes())
+            .catch(() => null),
+    ]).then(([countriesModule, flagModule, nationCodes]) => ({
+        allNationalities: (locale?: string) =>
+            countriesModule.allNationalities(locale, nationCodes),
         countryName: countriesModule.countryName,
         CountryFlag: flagModule.CountryFlag,
     }));

--- a/src/components/ui/CountryCombobox.tsx
+++ b/src/components/ui/CountryCombobox.tsx
@@ -17,8 +17,14 @@ function loadCountryResources(): Promise<CountryResources> {
   cachedResources ??= Promise.all([
     import("../../lib/countries"),
     import("./CountryFlag"),
-  ]).then(([countriesModule, flagModule]) => ({
-    allNationalities: countriesModule.allNationalities,
+    // The backend catalog is the source of truth for selectable nationalities
+    // (#270). If it can't be fetched, fall back to the full ISO list.
+    import("../../services/nationsService")
+      .then((m) => m.getNationCodes())
+      .catch(() => null),
+  ]).then(([countriesModule, flagModule, nationCodes]) => ({
+    allNationalities: (locale?: string) =>
+      countriesModule.allNationalities(locale, nationCodes),
     countryName: countriesModule.countryName,
     CountryFlag: flagModule.CountryFlag,
   }));

--- a/src/lib/countries.test.ts
+++ b/src/lib/countries.test.ts
@@ -157,6 +157,25 @@ describe("allNationalities", () => {
     expect(codes).toContain("IE");
     expect(codes).not.toContain("GB");
   });
+
+  it("restricts the list to the allow-list when one is given (#270)", () => {
+    // Simulates the backend NATION_CATALOG being the source of truth: only
+    // catalog codes are offered, so no selectable nationality can fail import.
+    const list = allNationalities("en", ["ENG", "BR", "AM", "GW"]);
+    const codes = list.map((country) => country.code);
+
+    expect(codes.sort()).toEqual(["AM", "BR", "ENG", "GW"]);
+    // A valid ISO country outside the allow-list must not appear.
+    expect(codes).not.toContain("FR");
+  });
+
+  it("falls back to the full ISO list when the allow-list is empty or absent", () => {
+    const withEmpty = allNationalities("en", []).map((country) => country.code);
+    const withNull = allNationalities("en", null).map((country) => country.code);
+
+    expect(withEmpty).toContain("FR");
+    expect(withNull).toContain("FR");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -218,10 +218,10 @@ export function allCountries(locale = "en"): { code: string; name: string }[] {
  * Get selectable nationalities for football-facing UI.
  * This excludes legacy GB while surfacing the UK football nations explicitly.
  *
- * When `allowedCodes` is given (the backend `NATION_CATALOG`, the single source
- * of truth for what the importer accepts — see #270), the list is restricted to
- * those codes so the UI never offers a nationality that would fail import. When
- * omitted, every ISO nationality is offered (graceful fallback).
+ * When `allowedCodes` is given (the backend's combined nation catalog, the
+ * single source of truth for what the importer accepts — see #270), the list is
+ * restricted to those codes so the UI never offers a nationality that would fail
+ * import. When omitted, every ISO nationality is offered (graceful fallback).
  */
 export function allNationalities(
   locale = "en",

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -217,8 +217,22 @@ export function allCountries(locale = "en"): { code: string; name: string }[] {
 /**
  * Get selectable nationalities for football-facing UI.
  * This excludes legacy GB while surfacing the UK football nations explicitly.
+ *
+ * When `allowedCodes` is given (the backend `NATION_CATALOG`, the single source
+ * of truth for what the importer accepts — see #270), the list is restricted to
+ * those codes so the UI never offers a nationality that would fail import. When
+ * omitted, every ISO nationality is offered (graceful fallback).
  */
-export function allNationalities(locale = "en"): { code: string; name: string }[] {
+export function allNationalities(
+  locale = "en",
+  allowedCodes?: readonly string[] | null,
+): { code: string; name: string }[] {
+  const allow =
+    allowedCodes && allowedCodes.length > 0
+      ? new Set(allowedCodes.map((code) => code.toUpperCase()))
+      : null;
+  const isAllowed = (code: string): boolean => !allow || allow.has(code.toUpperCase());
+
   const footballCodes = new Set(
     Object.values(FOOTBALL_IDENTITIES)
       .filter((identity) => identity.selectable)
@@ -226,11 +240,11 @@ export function allNationalities(locale = "en"): { code: string; name: string }[
   );
 
   const isoNationalities = allCountries(locale)
-    .filter(({ code }) => code !== "GB" && !footballCodes.has(code))
+    .filter(({ code }) => code !== "GB" && !footballCodes.has(code) && isAllowed(code))
     .map(({ code }) => ({ code, name: countryName(code, locale) }));
 
   const footballNationalities = Object.values(FOOTBALL_IDENTITIES)
-    .filter((identity) => identity.selectable)
+    .filter((identity) => identity.selectable && isAllowed(identity.code))
     .map((identity) => ({
       code: identity.code,
       name: countryName(identity.code, locale),

--- a/src/services/nationsService.ts
+++ b/src/services/nationsService.ts
@@ -1,0 +1,32 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * A selectable football nation, mirrored from the backend `NATION_CATALOG`.
+ * This catalog is the single source of truth for which nationalities are
+ * selectable and importable (see #270), so the UI reads it rather than offering
+ * every ISO country.
+ */
+export interface NationInfo {
+  code: string;
+  name: string;
+  region: string;
+}
+
+let cache: Promise<NationInfo[]> | null = null;
+
+/** Fetch the nation catalog from the backend, cached for the session. */
+export function getNations(): Promise<NationInfo[]> {
+  cache ??= invoke<NationInfo[]>("get_nations");
+  return cache;
+}
+
+/** The catalog's nation codes, for filtering selectable nationalities. */
+export async function getNationCodes(): Promise<string[]> {
+  const nations = await getNations();
+  return nations.map((nation) => nation.code);
+}
+
+/** Testing hook: drop the cached catalog so the next call refetches. */
+export function resetNationsCache(): void {
+  cache = null;
+}

--- a/src/services/nationsService.ts
+++ b/src/services/nationsService.ts
@@ -1,10 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 
 /**
- * A selectable football nation, mirrored from the backend `NATION_CATALOG`.
- * This catalog is the single source of truth for which nationalities are
- * selectable and importable (see #270), so the UI reads it rather than offering
- * every ISO country.
+ * A selectable football nation, mirrored from the backend's combined nation
+ * catalog (`all_nations()` — World Cup pool + wider FIFA membership). That
+ * catalog is the single source of truth for which nationalities are selectable
+ * and importable (see #270), so the UI reads it rather than offering every ISO
+ * country.
  */
 export interface NationInfo {
   code: string;


### PR DESCRIPTION
## Problem
The world editor offered every ISO country, but the importer only accepted the ~67-nation World Cup catalog. Picking Armenia, Guinea-Bissau, Antarctica, etc. made the resulting package fail to import with a generic `be.error.package.invalid`.

## Fix
Make the backend nation catalog the single source of truth for selectable nationalities — **without disturbing the World Cup**:

- Split into `NATION_CATALOG` (curated World Cup pool, unchanged — qualifying still synthesises its field from exactly these) and a new `ADDITIONAL_NATIONS` list covering the rest of the FIFA membership.
- Lookups resolve against `all_nations()` (the union); the new `get_nations` command and the importer accept/offer every real nationality, while the World Cup keeps reading only `NATION_CATALOG`.
- Frontend: `CountryCombobox` / manager-creation fetch the catalog via `get_nations` and restrict the dropdown to it, so the UI can no longer offer a nationality the importer would reject. Falls back to the full ISO list if the fetch fails.
- Surface the specific validation error (which country/entity) instead of a generic "invalid package", via the existing `key?param=value` backend-i18n convention.

## Why decoupled
`NATION_CATALOG` doubles as the World Cup qualifying pool (`select_field`). Expanding it directly tripled the qualifying field and broke the match-spread scheduler. Keeping the WC pool curated and adding a separate selectable list fixes #270 with zero World Cup impact.

## Tests
- ofm_core full suite green (incl. the WC scheduler test).
- Decoupling contract: additional nations are never WC entrants; global code uniqueness.
- #270 regression: Armenia/Guinea-Bissau selectable, Antarctica & bare GB excluded.
- Frontend allow-list filtering; catalog codes verified to resolve to names + flags.

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the selectable nationality list to include additional FIFA nations via a backend nations catalog (code, name, region).
  - Added a new backend command to provide the full nations catalog to the frontend, which is now cached to reduce repeated fetches.

- **Bug Fixes**
  - Package loading and merging now surface the first detailed validation error instead of a generic message.

- **Tests**
  - Updated nationality and nation selection test coverage to verify correct allow-list filtering, code uniqueness, and expected fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->