### PR TITLE
fix(transfers): convert counter-offer suggestion to millions before pre-fill (#300)

### DIFF
--- a/src/components/transfers/useTransferBidFlow.test.tsx
+++ b/src/components/transfers/useTransferBidFlow.test.tsx
@@ -279,4 +279,40 @@ describe("useTransferBidFlow", function (): void {
         await new Promise((resolve) => setTimeout(resolve, 2100));
         expect(screen.getByLabelText("bid-result")).toHaveTextContent("accepted");
     });
+
+    it("pre-fills a counter-offer suggestion in millions, not raw euros", async function (): Promise<void> {
+        // Regression for #300: `suggested_fee` is raw euros, but this input is
+        // millions-denominated. If it isn't converted, "650000" in a millions
+        // input becomes a €650 billion resubmit (1,000,000× too large).
+        const target = createPlayer();
+        const gameState = createGameState([target]);
+        mockedMakeTransferBid.mockResolvedValue({
+            decision: "counter_offer",
+            suggested_fee: 650000,
+            is_terminal: false,
+            feedback: {
+                mood: "firm",
+                headline_key: "transfers.transferFeedbackCounterHeadline",
+                detail_key: "transfers.transferFeedbackCounterDetail",
+                tension: 40,
+                patience: 60,
+                round: 1,
+                params: { fee: "650000" },
+            },
+            game: gameState,
+        });
+
+        render(<HookHarness gameState={gameState} target={target} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Open" }));
+        fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+        await waitFor(function (): void {
+            expect(screen.getByLabelText("bid-result")).toHaveTextContent(
+                "counter_offer",
+            );
+        });
+
+        expect(screen.getByLabelText("Bid amount")).toHaveValue("0.65");
+    });
 });

--- a/src/components/transfers/useTransferBidFlow.ts
+++ b/src/components/transfers/useTransferBidFlow.ts
@@ -15,7 +15,6 @@ import {
 } from "../../services/transfersService";
 import {
     buildResumedBidFeedback,
-    formatTransferFeeInput,
     getOutgoingNegotiationOffer,
     normalizeTransferNegotiationFeedback,
 } from "./TransfersTab.helpers";
@@ -142,8 +141,11 @@ export function useTransferBidFlow({
             setBidFeedback(normalizeTransferNegotiationFeedback(response.feedback));
             onGameUpdate?.(response.game);
 
+            // `suggested_fee` is in raw euros, but this input is denominated in
+            // millions (see `bidFee` above and `openBidNegotiation`). Convert
+            // before pre-filling, or the next submit sends 1,000,000× the value.
             if (response.suggested_fee !== null) {
-                setBidAmount(formatTransferFeeInput(response.suggested_fee));
+                setBidAmount((response.suggested_fee / 1_000_000).toFixed(2));
             }
         } catch (error: any) {
             setBidResult(error?.toString() || "error");


### PR DESCRIPTION
## Problem
The bid amount input in `useTransferBidFlow` is denominated in **millions**, but a returned counter-offer `suggested_fee` (raw euros) was fed straight into the input via `formatTransferFeeInput`. Re-submitting the pre-filled value then sent `suggested_fee * 1_000_000` — e.g. a €650,000 counter became a **€650bn** bid. This is symptom #1 from #300.

## Fix
Divide `suggested_fee` by 1,000,000 and format it like `openBidNegotiation` does, so the counter path matches the input's unit convention. `formatTransferFeeInput` is left untouched — its other callers (`TransfersTab.tsx`) are correctly raw-euro surfaces.

## Tests
Added a regression test asserting a €650k counter pre-fills as `0.65`, not `650000`. Full bid-flow suite green, `tsc` clean.

## Scope
This is just the 1,000,000× hotfix. The rest of #300 (`formatVal → formatExactMoney` swaps, wage-line/cash-runway unit labels) remains open for a follow-up.

Part of #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected counter-offer handling so suggested transfer fees are displayed in the bid amount field using millions formatting.
  * Ensured a suggested fee of €650,000 appears as €0.65 in the input.
  * Added regression coverage for this counter-offer scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->