### PR TITLE
fix(transfers): stop deal-workspace cues reading as false confirmations (#305)

### DIFF
--- a/src/components/transfers/PlayerDealWorkspace.test.tsx
+++ b/src/components/transfers/PlayerDealWorkspace.test.tsx
@@ -213,4 +213,32 @@ describe("PlayerDealWorkspace", () => {
     expect(screen.getByText("Open a transfer negotiation.")).toBeInTheDocument();
     expect(screen.getByText("Available for transfer.")).toBeInTheDocument();
   });
+
+  it("shows the reason (not the description or metadata) for a disabled route (#305)", () => {
+    render(
+      <PlayerDealWorkspace
+        player={createPlayer({ transfer_listed: false, loan_listed: true })}
+        teams={[
+          createTeam(),
+          createTeam({ id: "team-2", name: "Beta FC", short_name: "BET" }),
+        ]}
+        myTeam={createTeam()}
+        annualSuffix="/yr"
+        transferWindowBlocksRegistration={false}
+        transferWindowSummary="Window open"
+        loanNoticeDetail={null}
+        selectedKind="loan"
+        onSelectKind={vi.fn()}
+        onClose={vi.fn()}
+        renderDealPanel={() => <div>Deal panel</div>}
+      />,
+    );
+
+    // The disabled (and unselected) transfer route shows its disabledReason as the
+    // subtitle — not the route description, and with no availability metadata line.
+    expect(screen.getByText("Not available for transfer.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Open a transfer negotiation."),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/transfers/PlayerDealWorkspace.test.tsx
+++ b/src/components/transfers/PlayerDealWorkspace.test.tsx
@@ -13,6 +13,8 @@ vi.mock("react-i18next", () => ({
       if (key === "common.ovr") return "OVR";
       if (key === "common.value") return "Value";
       if (key === "common.wage") return "Wage";
+      if (key === "common.currentWage") return "Current Wage";
+      if (key === "playerProfile.renewalWage") return "Offered Wage";
       if (key === "finances.transferBudget") return "Transfer Budget";
       if (key === "finances.wageBudget") return "Wage Budget";
       if (key === "transfers.dealType") return "Deal Type";
@@ -161,5 +163,54 @@ describe("PlayerDealWorkspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("separates current wage from the offered wage so a free agent's €0 does not contradict the offer (#305)", () => {
+    render(
+      <PlayerDealWorkspace
+        player={createPlayer({ team_id: null, wage: 0 })}
+        teams={[createTeam()]}
+        myTeam={createTeam()}
+        annualSuffix="/yr"
+        transferWindowBlocksRegistration={false}
+        transferWindowSummary="Window open"
+        loanNoticeDetail={null}
+        selectedKind="contract"
+        offeredWage={9000}
+        onSelectKind={vi.fn()}
+        onClose={vi.fn()}
+        renderDealPanel={() => <div>Deal panel</div>}
+      />,
+    );
+
+    // Both labels render as distinct rows — no lone ambiguous "Wage".
+    expect(screen.getByText("Current Wage")).toBeInTheDocument();
+    expect(screen.getByText("Offered Wage")).toBeInTheDocument();
+    expect(screen.queryByText("Wage")).not.toBeInTheDocument();
+  });
+
+  it("labels the selected route with its action, not availability copy (#305)", () => {
+    render(
+      <PlayerDealWorkspace
+        player={createPlayer()}
+        teams={[
+          createTeam(),
+          createTeam({ id: "team-2", name: "Beta FC", short_name: "BET" }),
+        ]}
+        myTeam={createTeam()}
+        annualSuffix="/yr"
+        transferWindowBlocksRegistration={false}
+        transferWindowSummary="Window open"
+        loanNoticeDetail={null}
+        selectedKind="transfer"
+        onSelectKind={vi.fn()}
+        onClose={vi.fn()}
+        renderDealPanel={() => <div>Deal panel</div>}
+      />,
+    );
+
+    // Subtitle describes the route; availability is only secondary metadata.
+    expect(screen.getByText("Open a transfer negotiation.")).toBeInTheDocument();
+    expect(screen.getByText("Available for transfer.")).toBeInTheDocument();
   });
 });

--- a/src/components/transfers/PlayerDealWorkspace.tsx
+++ b/src/components/transfers/PlayerDealWorkspace.tsx
@@ -26,6 +26,12 @@ interface PlayerDealWorkspaceProps {
   transferWindowSummary: string;
   loanNoticeDetail: string | null;
   selectedKind: DealKind;
+  /**
+   * Live wage being offered in the active deal (same units as `player.wage`),
+   * or null when the route has no wage offer. Shown alongside the player's
+   * current wage so the two never read as one contradictory figure (#305).
+   */
+  offeredWage?: number | null;
   onSelectKind: (kind: DealKind) => void;
   onClose: () => void;
   renderDealPanel: (kind: DealKind) => ReactNode;
@@ -86,6 +92,7 @@ export default function PlayerDealWorkspace({
   transferWindowSummary,
   loanNoticeDetail,
   selectedKind,
+  offeredWage,
   onSelectKind,
   onClose,
   renderDealPanel,
@@ -241,9 +248,16 @@ export default function PlayerDealWorkspace({
                       <span className="font-heading text-sm font-bold uppercase tracking-wider">
                         {option.title}
                       </span>
+                      {/* Subtitle describes the route action, not availability, so a
+                          selected route never reads as a confirmed deal (#305). */}
                       <span className="mt-1 block text-xs text-gray-500 dark:text-gray-300">
-                        {option.disabledReason ?? option.detail}
+                        {option.disabledReason ?? option.description}
                       </span>
+                      {!disabled ? (
+                        <span className="mt-1 block text-[10px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-400">
+                          {option.detail}
+                        </span>
+                      ) : null}
                     </span>
                   </span>
                 </button>
@@ -286,12 +300,20 @@ export default function PlayerDealWorkspace({
                   </p>
                 </div>
                 <div>
-                  <p className={factLabelClass()}>{t("common.wage")}</p>
+                  <p className={factLabelClass()}>{t("common.currentWage")}</p>
                   <p className={`${factValueClass()} tabular-nums`}>
                     {formatAnnualAmount(formatVal(player.wage), annualSuffix)}
                   </p>
                 </div>
               </div>
+              {offeredWage != null && offeredWage > 0 ? (
+                <div className="mt-3 border-t border-gray-100 pt-3 dark:border-navy-700">
+                  <p className={factLabelClass()}>{t("playerProfile.renewalWage")}</p>
+                  <p className={`${factValueClass()} tabular-nums`}>
+                    {formatAnnualAmount(formatVal(offeredWage), annualSuffix)}
+                  </p>
+                </div>
+              ) : null}
             </div>
 
             {myTeam ? (

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -1837,6 +1837,9 @@ export default function TransfersTab({
           transferWindowSummary={transferWindowSummary}
           loanNoticeDetail={loanWindowNoticeDetail}
           selectedKind={dealWorkspaceKind}
+          offeredWage={
+            dealWorkspaceKind === "contract" ? Number(contractWage) : null
+          }
           onSelectKind={(kind) =>
             selectDealWorkspaceKind(dealWorkspaceTarget, kind)
           }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -401,6 +401,7 @@
     "potLimited": "Omezený"
   },
   "common": {
+    "currentWage": "Současný plat",
     "loading": "Nahrávání...",
     "loadingGameState": "Nahrávání stavu...",
     "noResults": "Výsledky nenalezeny.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -401,6 +401,7 @@
     "promoteToSeniorSquad": "In den Profikader befördern"
   },
   "common": {
+    "currentWage": "Aktuelles Gehalt",
     "loading": "Lädt...",
     "loadingGameState": "Spielstand wird geladen...",
     "noResults": "Keine Ergebnisse gefunden.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -401,6 +401,7 @@
     "potLimited": "Limited"
   },
   "common": {
+    "currentWage": "Current Wage",
     "loading": "Loading...",
     "loadingGameState": "Loading game state...",
     "noResults": "No results found.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -433,6 +433,7 @@
     "promoteToSeniorSquad": "Ascender al primer equipo"
   },
   "common": {
+    "currentWage": "Salario actual",
     "loading": "Cargando...",
     "loadingGameState": "Cargando estado del juego...",
     "noResults": "No se encontraron resultados.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -401,6 +401,7 @@
     "promoteToSeniorSquad": "Promouvoir en équipe première"
   },
   "common": {
+    "currentWage": "Salaire actuel",
     "loading": "Chargement...",
     "loadingGameState": "Chargement de l'état du jeu...",
     "noResults": "Aucun résultat trouvé.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -420,6 +420,7 @@
     "promoteToSeniorSquad": "Promuovi in prima squadra"
   },
   "common": {
+    "currentWage": "Stipendio attuale",
     "loading": "Caricamento...",
     "loadingGameState": "Caricamento stato di gioco...",
     "noResults": "Nessun risultato trovato.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -401,6 +401,7 @@
     "promoteToSeniorSquad": "Promover ao elenco principal"
   },
   "common": {
+    "currentWage": "Salário atual",
     "loading": "Carregando...",
     "loadingGameState": "Carregando estado do jogo...",
     "noResults": "Nenhum resultado encontrado.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -401,6 +401,7 @@
     "promoteToSeniorSquad": "Promover à equipa principal"
   },
   "common": {
+    "currentWage": "Salário atual",
     "loading": "A carregar...",
     "loadingGameState": "A carregar estado do jogo...",
     "noResults": "Nenhum resultado encontrado.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -401,6 +401,7 @@
     "potLimited": "Ограниченный"
   },
   "common": {
+    "currentWage": "Текущая зарплата",
     "loading": "Загрузка...",
     "loadingGameState": "Загрузка состояния игры...",
     "noResults": "Ничего не найдено.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -401,6 +401,7 @@
     "potLimited": "Sınırlı"
   },
   "common": {
+    "currentWage": "Mevcut maaş",
     "loading": "Yükleniyor...",
     "loadingGameState": "Oyun durumu yükleniyor...",
     "noResults": "Sonuç bulunamadı.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -401,6 +401,7 @@
     "potLimited": "有限"
   },
   "common": {
+    "currentWage": "当前工资",
     "loading": "加载中……",
     "loadingGameState": "加载游戏状态中……",
     "noResults": "未找到结果。",


### PR DESCRIPTION
## Problem
Two spots in `PlayerDealWorkspace` where neutral info read as "your action succeeded":
1. The route subtitle showed **availability** copy ("The club is open to a permanent sale."), which — next to the selected-route highlight — read like a confirmed deal.
2. The sidebar showed the player's **current** WAGE (`€0/yr` for a free agent) right next to the OFFERED WAGE input — two contradictory wage figures.

## Fix
- **Route subtitle** now describes the *route action* (e.g. "Permanent move with a transfer fee.") using the existing `description` copy; availability drops to a small secondary metadata line.
- **Wage split** — the sidebar now shows **CURRENT WAGE** and a live **OFFERED WAGE** row (fed from the contract flow via a new `offeredWage` prop), so the free agent's €0 current wage no longer reads as one contradictory number.

## Note on the accent colour
The issue also suggested recolouring the selected route away from green. I prototyped blue/amber but kept it **primary (green)** — the false signal was in the *copy* and the lone wage figure, not the selection colour, and green selection is consistent with the rest of the app. Green is not used to imply a confirmed deal anywhere here.

## i18n / tests
- Adds `common.currentWage` across all 11 locales (coverage tests enforce parity); OFFERED WAGE reuses `playerProfile.renewalWage`.
- New `PlayerDealWorkspace` tests: current/offered wage are distinct rows; the route subtitle shows the action, not availability. `tsc` clean; transfers + i18n suites green.

Closes #305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate “Current Wage” and “Offered Wage” details in player deal negotiations when an offered wage is available.
  * Updated transfer deal options so availability messaging and action descriptions are communicated more clearly.
  * Added localized “Current Wage” labels across supported languages.
* **Bug Fixes**
  * Clarified wage display for free agents when `wage = 0` but an offered wage exists.
  * Improved transfer subtitle behavior for enabled versus disabled route selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->