### PR TITLE
fix(transfers): take players with a pending registration off the market

### DIFF
--- a/src/components/transfers/TransferBidModal.test.tsx
+++ b/src/components/transfers/TransferBidModal.test.tsx
@@ -336,4 +336,47 @@ describe("TransferBidModal", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Submit Bid" })).toBeDisabled();
   });
+
+  it("also blocks when the pending registration is a loan offer", () => {
+    const target = createPlayer({
+      transfer_offers: [],
+      loan_offers: [
+        {
+          id: "loan-offer-1",
+          from_team_id: "team-1",
+          parent_team_id: "team-2",
+          start_date: "2026-08-01",
+          end_date: "2027-01-01",
+          wage_contribution_pct: 75,
+          status: "PendingRegistration",
+          date: "2026-08-01",
+        },
+      ],
+    });
+
+    render(
+      <TransferBidModal
+        bidTarget={target}
+        teams={[createTeam(), createTeam({ id: "team-2", name: "Seller FC" })]}
+        bidAmount="1.0"
+        onBidAmountChange={vi.fn()}
+        myTeam={createTeam()}
+        bidFee={1000000}
+        bidProjection={createProjection()}
+        bidFeedback={null}
+        activeBidOffer={null}
+        hasExistingOffer={false}
+        bidResult={null}
+        bidLoading={false}
+        bidSubmitDisabled={false}
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Already agreed — awaiting registration"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit Bid" })).toBeDisabled();
+  });
 });

--- a/src/components/transfers/TransferBidModal.test.tsx
+++ b/src/components/transfers/TransferBidModal.test.tsx
@@ -57,6 +57,9 @@ vi.mock("react-i18next", () => ({
       if (key === "transfers.submitBid") return "Submit Bid";
       if (key === "transfers.submitting") return "Submitting";
       if (key === "transfers.close") return "Close";
+      if (key === "transfers.bidBlockedPendingRegistration") {
+        return "Already agreed — awaiting registration";
+      }
       return key;
     },
   }),
@@ -298,5 +301,39 @@ describe("TransferBidModal", () => {
     expect(submitButton).toHaveAttribute("type", "button");
     expect(closeButton).toHaveAttribute("type", "button");
     expect(submitButton).not.toBeDisabled();
+  });
+
+  it("blocks and explains when the player already has a pending registration", () => {
+    // Reachable from a profile / squad / scouting action even though the market
+    // list hides such players. The form must self-block regardless of what the
+    // parent passes for bidSubmitDisabled.
+    const target = createPlayer({
+      transfer_offers: [createOffer({ status: "PendingRegistration" })],
+    });
+
+    render(
+      <TransferBidModal
+        bidTarget={target}
+        teams={[createTeam(), createTeam({ id: "team-2", name: "Seller FC" })]}
+        bidAmount="1.0"
+        onBidAmountChange={vi.fn()}
+        myTeam={createTeam()}
+        bidFee={1000000}
+        bidProjection={createProjection()}
+        bidFeedback={null}
+        activeBidOffer={null}
+        hasExistingOffer={false}
+        bidResult={null}
+        bidLoading={false}
+        bidSubmitDisabled={false}
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Already agreed — awaiting registration"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit Bid" })).toBeDisabled();
   });
 });

--- a/src/components/transfers/TransferBidModal.tsx
+++ b/src/components/transfers/TransferBidModal.tsx
@@ -22,6 +22,7 @@ import NegotiationFeedbackPanel, {
 import { Badge } from "../ui";
 import { translatePositionAbbreviation } from "../squad/SquadTab.helpers";
 import TransferNegotiationHistory from "./TransferNegotiationHistory";
+import { playerHasPendingRegistration } from "./TransfersTab.model";
 
 export interface TransferBidFormProps {
   bidTarget: PlayerData;
@@ -68,6 +69,10 @@ export function TransferBidForm({
 }: TransferBidFormProps) {
   const { t } = useTranslation();
   const titleId = `transfer-bid-modal-title-${bidTarget.id}`;
+  // A player with an agreed deal awaiting registration is off the market — the
+  // engine refuses a new bid. Surface it here so reaching this form from a
+  // profile / squad / scouting action explains itself instead of dead-ending.
+  const pendingRegistration = playerHasPendingRegistration(bidTarget);
 
   return (
     <>
@@ -108,6 +113,15 @@ export function TransferBidForm({
             </p>
             {blockingDetail ? <p className="mt-1">{blockingDetail}</p> : null}
           </div>
+        </div>
+      ) : null}
+      {pendingRegistration ? (
+        <div
+          role="alert"
+          className="mb-4 flex gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <p className="text-xs">{t("transfers.bidBlockedPendingRegistration")}</p>
         </div>
       ) : null}
       {hasExistingOffer ? (
@@ -218,7 +232,7 @@ export function TransferBidForm({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={bidSubmitDisabled}
+          disabled={bidSubmitDisabled || pendingRegistration}
           className="flex-1 py-2 bg-primary-700 hover:bg-primary-800 text-white rounded-lg font-heading font-bold text-sm uppercase tracking-wider transition-colors disabled:opacity-50"
         >
           {bidLoading ? t("transfers.submitting") : t("transfers.submitBid")}

--- a/src/components/transfers/TransfersTab.model.test.ts
+++ b/src/components/transfers/TransfersTab.model.test.ts
@@ -303,6 +303,46 @@ describe("TransfersTab.model", () => {
     ).toEqual(["dual-listed"]);
   });
 
+  it("hides transfer-listed players with a pending registration from the market", () => {
+    // A transfer-listed player whose move is already agreed and awaiting
+    // registration is off the market — no one can bid again (#305 follow-up).
+    const boughtPlayer = createPlayer({
+      id: "bought",
+      team_id: "team-2",
+      transfer_listed: true,
+      transfer_offers: [
+        {
+          id: "offer-1",
+          from_team_id: "team-1",
+          fee: 900000,
+          wage_offered: 0,
+          last_manager_fee: 900000,
+          negotiation_round: 1,
+          suggested_counter_fee: null,
+          status: "PendingRegistration",
+          date: "2026-06-01",
+          registration_date: "2027-01-02",
+        },
+      ],
+    });
+    const stillAvailable = createPlayer({
+      id: "available",
+      team_id: "team-2",
+      transfer_listed: true,
+    });
+    const gameState = createGameState([boughtPlayer, stillAvailable]);
+
+    const collections = deriveTransferCollections(gameState, "team-1");
+
+    expect(collections.marketPlayers.map((player) => player.id)).toEqual([
+      "available",
+    ]);
+    // It still surfaces under "offers" so the manager can track the agreed deal.
+    expect(collections.playersWithOffers.map((player) => player.id)).toContain(
+      "bought",
+    );
+  });
+
   it("filters by position and search text", () => {
     const players = [
       createPlayer({

--- a/src/components/transfers/TransfersTab.model.test.ts
+++ b/src/components/transfers/TransfersTab.model.test.ts
@@ -375,6 +375,10 @@ describe("TransfersTab.model", () => {
     expect(collections.loanPlayers.map((player) => player.id)).toEqual([
       "loan-available",
     ]);
+    // It still surfaces under "offers" so the manager can track the agreed loan.
+    expect(collections.playersWithOffers.map((player) => player.id)).toContain(
+      "loan-bought",
+    );
   });
 
   it("filters by position and search text", () => {

--- a/src/components/transfers/TransfersTab.model.test.ts
+++ b/src/components/transfers/TransfersTab.model.test.ts
@@ -343,6 +343,40 @@ describe("TransfersTab.model", () => {
     );
   });
 
+  it("hides loan-listed players with a pending loan registration from the loan market", () => {
+    // Symmetric to the transfer case: a pending-registration loan offer takes the
+    // player off the loan market (guards the loan_offers branch of the helper).
+    const loanBought = createPlayer({
+      id: "loan-bought",
+      team_id: "team-2",
+      loan_listed: true,
+      loan_offers: [
+        {
+          id: "loan-offer-1",
+          from_team_id: "team-1",
+          parent_team_id: "team-2",
+          start_date: "2026-08-01",
+          end_date: "2027-01-01",
+          wage_contribution_pct: 75,
+          status: "PendingRegistration",
+          date: "2026-08-01",
+        },
+      ],
+    });
+    const loanAvailable = createPlayer({
+      id: "loan-available",
+      team_id: "team-2",
+      loan_listed: true,
+    });
+    const gameState = createGameState([loanBought, loanAvailable]);
+
+    const collections = deriveTransferCollections(gameState, "team-1");
+
+    expect(collections.loanPlayers.map((player) => player.id)).toEqual([
+      "loan-available",
+    ]);
+  });
+
   it("filters by position and search text", () => {
     const players = [
       createPlayer({

--- a/src/components/transfers/TransfersTab.model.ts
+++ b/src/components/transfers/TransfersTab.model.ts
@@ -60,6 +60,24 @@ export function getMyListedPlayers(
   ]);
 }
 
+/**
+ * True when a player is committed to a move that is agreed and only awaiting
+ * registration (a `PendingRegistration` transfer or loan offer). Such a player
+ * is off the market — no club, including the one that agreed the deal, can open
+ * a new bid — so they are hidden from the approachable lists and the bid flow
+ * refuses further offers.
+ */
+export function playerHasPendingRegistration(player: PlayerData): boolean {
+  return (
+    (player.transfer_offers ?? []).some(
+      (offer) => offer.status === "PendingRegistration",
+    ) ||
+    (player.loan_offers ?? []).some(
+      (offer) => offer.status === "PendingRegistration",
+    )
+  );
+}
+
 export function deriveTransferCollections(
   gameState: GameStateData,
   userTeamId: string | null,
@@ -76,14 +94,20 @@ export function deriveTransferCollections(
   );
   const marketPlayers = gameState.players.filter(
     (player) =>
-      player.transfer_listed && player.team_id !== userTeamId && !player.active_loan,
+      player.transfer_listed &&
+      player.team_id !== userTeamId &&
+      !player.active_loan &&
+      !playerHasPendingRegistration(player),
   );
   const freeAgentPlayers = gameState.players.filter(
     (player) => player.team_id === null && !player.retired,
   );
   const loanPlayers = gameState.players.filter(
     (player) =>
-      player.loan_listed && player.team_id !== userTeamId && !player.active_loan,
+      player.loan_listed &&
+      player.team_id !== userTeamId &&
+      !player.active_loan &&
+      !playerHasPendingRegistration(player),
   );
 
   return {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Týdenní mzdové náklady {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Týdenní mzdový rozpočet {{budget}}",
     "bidImpactIncomingWage": "Mzda hráče {{wage}} / týden",
+    "bidBlockedPendingRegistration": "Tento hráč již dohodl přestup a čeká na registraci.",
     "centre": "Přestupové centrum",
     "transferWindow": "{{team}} — Přestupové okno",
     "myTransferList": "Moje přestupová listina",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Wöchentliche Gehaltssumme {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Wöchentliches Gehaltsbudget {{budget}}",
     "bidImpactIncomingWage": "Gehalt des Spielers {{wage}} / Woche",
+    "bidBlockedPendingRegistration": "Dieser Spieler hat bereits einem Transfer zugestimmt und wartet auf die Registrierung.",
     "centre": "Transferzentrum",
     "transferWindow": "{{team}} — Transferfenster",
     "myTransferList": "Meine Transferliste",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Weekly wage bill {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Weekly wage budget {{budget}}",
     "bidImpactIncomingWage": "Incoming player wage {{wage}} / week",
+    "bidBlockedPendingRegistration": "This player has already agreed a transfer and is awaiting registration.",
     "centre": "Transfer Centre",
     "transferWindow": "{{team}} — Transfer Window",
     "myTransferList": "My Transfer List",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1290,6 +1290,7 @@
     "bidImpactWageBill": "Masa salarial semanal {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Presupuesto salarial semanal {{budget}}",
     "bidImpactIncomingWage": "Salario del jugador {{wage}} / semana",
+    "bidBlockedPendingRegistration": "Este jugador ya ha acordado un traspaso y está pendiente de inscripción.",
     "centre": "Centro de Fichajes",
     "transferWindow": "{{team}} — Mercado de Fichajes",
     "myTransferList": "Mi Lista de Fichajes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Masse salariale hebdomadaire {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Budget salarial hebdomadaire {{budget}}",
     "bidImpactIncomingWage": "Salaire du joueur {{wage}} / semaine",
+    "bidBlockedPendingRegistration": "Ce joueur a déjà accepté un transfert et attend son enregistrement.",
     "centre": "Centre de Transferts",
     "transferWindow": "{{team}} — Mercato",
     "myTransferList": "Ma liste de transferts",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1277,6 +1277,7 @@
     "bidImpactWageBill": "Monte ingaggi settimanale {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Budget ingaggi settimanale {{budget}}",
     "bidImpactIncomingWage": "Ingaggio del giocatore {{wage}} / settimana",
+    "bidBlockedPendingRegistration": "Questo giocatore ha già concordato un trasferimento ed è in attesa di registrazione.",
     "centre": "Centro trasferimenti",
     "transferWindow": "{{team}} — Finestra di mercato",
     "myTransferList": "La mia lista trasferimenti",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Folha salarial semanal {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Orçamento salarial semanal {{budget}}",
     "bidImpactIncomingWage": "Salário do jogador {{wage}} / semana",
+    "bidBlockedPendingRegistration": "Este jogador já acertou uma transferência e aguarda o registro.",
     "centre": "Central de Transferências",
     "transferWindow": "{{team}} — Janela de Transferências",
     "myTransferList": "Minha Lista de Transferências",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Massa salarial semanal {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Orçamento salarial semanal {{budget}}",
     "bidImpactIncomingWage": "Salário do jogador {{wage}} / semana",
+    "bidBlockedPendingRegistration": "Este jogador já acordou uma transferência e aguarda o registo.",
     "centre": "Centro de Transferências",
     "transferWindow": "{{team}} — Janela de Transferências",
     "myTransferList": "A Minha Lista",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Недельный фонд зарплат {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Недельный бюджет зарплат {{budget}}",
     "bidImpactIncomingWage": "Зарплата игрока {{wage}} / неделя",
+    "bidBlockedPendingRegistration": "Этот игрок уже согласовал переход и ожидает регистрации.",
     "centre": "Трансферный центр",
     "transferWindow": "Трансферное окно — {{team}}",
     "myTransferList": "Мой трансферный список",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "Haftalık maaş gideri {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "Haftalık maaş bütçesi {{budget}}",
     "bidImpactIncomingWage": "Oyuncu maaşı {{wage}} / hafta",
+    "bidBlockedPendingRegistration": "Bu oyuncu bir transferi kabul etti ve tescili bekliyor.",
     "centre": "Transfer Merkezi",
     "transferWindow": "{{team}} — Transfer Dönemi",
     "myTransferList": "Transfer Listem",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1258,6 +1258,7 @@
     "bidImpactWageBill": "每周工资总额 {{before}} → {{after}}",
     "bidImpactWeeklyWageBudget": "每周工资预算 {{budget}}",
     "bidImpactIncomingWage": "球员周薪 {{wage}}",
+    "bidBlockedPendingRegistration": "该球员已达成转会协议，正在等待注册。",
     "centre": "转会中心",
     "transferWindow": "{{team}} — 转会窗口",
     "myTransferList": "我的转会名单",


### PR DESCRIPTION
## Problem
Found while debugging "why can't I submit a bid": a player whose transfer is already agreed and awaiting registration (`status: PendingRegistration`) is committed to the move — the engine correctly refuses a new bid (`project_transfer_bid_financial_impact` → `player_has_pending_registration` → error). But the UI didn't reflect it:

- The player **stayed in the transfer market list**, so you could still open a bid on someone you'd already bought.
- The bid flow **swallowed the projection error** (`catch { setBidProjection(null) }`), so Submit was silently disabled with **no message and no impact panel** — a dead button. Reproduced live: FC Munich already had a €900k `PendingRegistration` offer on the target, registering 2027-01-02.

## Fix
- Add `playerHasPendingRegistration(player)` and filter such players out of the approachable **market/loan lists** in `deriveTransferCollections`. They still appear under **"offers"** so the agreed deal stays trackable.
- `TransferBidForm` now detects the pending registration on the target, shows a clear notice, and **self-disables Submit regardless of the parent's `bidSubmitDisabled`** — so reaching the form from a profile / squad / scouting action explains itself instead of dead-ending (the list filter alone can't cover those entry points).

## Scope note
This is the minimal, correct UX fix. Two adjacent things I deliberately left out of scope: (1) generally surfacing swallowed projection errors in the bid flow, and (2) the odd registration deferral (a June deal deferring to January with the window open) — both worth a later look.

## Tests
- Market list hides a bought (`PendingRegistration`) player but still lists him under offers.
- The bid form renders the notice and disables Submit even when the parent passes `bidSubmitDisabled=false`.
- Adds `transfers.bidBlockedPendingRegistration` across all 11 locales (coverage tests enforce parity). `tsc` clean; transfers + i18n suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer bids are now blocked when the target player has an agreement pending registration, with an amber alert shown in the bid modal.
  * The “Submit bid” action is disabled when the player is blocked, even if submission would otherwise be permitted.
  * Players with pending-registration offers are excluded from the transfer/loan markets, while still appearing in offer tracking.
  * Added the new “bidBlockedPendingRegistration” message across supported languages.
* **Tests**
  * Added coverage for pending-registration bid blocking (transfer + loan) and related market filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->