### PR TITLE
feat: added team founding year field to the world editor and referenc…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "**/*.rpa": true,
     "**/*.rpymc": true,
     "**/cache/": true
-  }
+  },
+  "markdown.validate.enabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,5 @@
     "**/*.rpa": true,
     "**/*.rpymc": true,
     "**/cache/": true
-  },
-  "markdown.validate.enabled": true
+  }
 }

--- a/docs/modding/PACKAGE_EDITOR.md
+++ b/docs/modding/PACKAGE_EDITOR.md
@@ -104,6 +104,7 @@ Each team has the following fields:
 | **Team ID** | Stable slug used to reference this team in players and competitions. Auto-generated from the name if left empty. Example: `fc-northshire`. |
 | **Team Name** | Full display name. Example: `FC Northshire`. |
 | **Short Name** | 2–5 character abbreviation for standings tables. Example: `NSH`. |
+| **Founded Year** | Optional year the team was founded. Example: `2005`. |
 | **City** | City the team is based in. |
 | **Country** | Football country code. Must match a built-in code or a country defined in your package. |
 | **Play Style** | Team's tactical tendency. One of: `Balanced`, `Attacking`, `Defensive`, `Counter`, `Pressing`. |

--- a/docs/modding/PACKAGE_EDITOR.md
+++ b/docs/modding/PACKAGE_EDITOR.md
@@ -104,7 +104,7 @@ Each team has the following fields:
 | **Team ID** | Stable slug used to reference this team in players and competitions. Auto-generated from the name if left empty. Example: `fc-northshire`. |
 | **Team Name** | Full display name. Example: `FC Northshire`. |
 | **Short Name** | 2–5 character abbreviation for standings tables. Example: `NSH`. |
-| **Founded Year** | Optional year the team was founded. Example: `2005`. |
+| **Founded Year** | Optional year the team was founded. If left empty, the engine draws a random year between 1880 and 1959 at world generation. Example: `2005`. |
 | **City** | City the team is based in. |
 | **Country** | Football country code. Must match a built-in code or a country defined in your package. |
 | **Play Style** | Team's tactical tendency. One of: `Balanced`, `Attacking`, `Defensive`, `Counter`, `Pressing`. |

--- a/docs/modding/SCHEMA_REFERENCE.md
+++ b/docs/modding/SCHEMA_REFERENCE.md
@@ -96,6 +96,7 @@ Defines a football club.
 | `reputationRange` | [integer, integer] or null | no | `null` | `[min, max]` reputation (0–1000). The game draws a random value in this range at world generation. Higher = more prestigious. |
 | `financeRange` | [integer, integer] or null | no | `null` | `[min, max]` budget in euros. The game draws a random value in this range at world generation. |
 | `logo` | string or null | no | `null` | Relative path to the team's logo image inside the package. Example: `"assets/logos/manchester-city.png"`. |
+| `foundedYear` | integer or null | no | `null` | Year the team was founded. Example: `2005`. |
 
 **Example:**
 ```json
@@ -110,7 +111,8 @@ Defines a football club.
   "playStyle": "Pressing",
   "stadiumName": "Etihad Stadium",
   "reputationRange": [850, 1000],
-  "financeRange": [50000000, 200000000]
+  "financeRange": [50000000, 200000000],
+  "foundedYear": 2005
 }
 ```
 

--- a/docs/modding/SCHEMA_REFERENCE.md
+++ b/docs/modding/SCHEMA_REFERENCE.md
@@ -96,7 +96,7 @@ Defines a football club.
 | `reputationRange` | [integer, integer] or null | no | `null` | `[min, max]` reputation (0–1000). The game draws a random value in this range at world generation. Higher = more prestigious. |
 | `financeRange` | [integer, integer] or null | no | `null` | `[min, max]` budget in euros. The game draws a random value in this range at world generation. |
 | `logo` | string or null | no | `null` | Relative path to the team's logo image inside the package. Example: `"assets/logos/manchester-city.png"`. |
-| `foundedYear` | integer or null | no | `null` | Year the team was founded. Example: `2005`. |
+| `foundedYear` | integer or null | no | `null` | Year the team was founded. If omitted or `null`, the game draws a random year between 1880 and 1959 at world generation. Example: `2005`. |
 
 **Example:**
 ```json

--- a/src-tauri/crates/ofm_core/src/generator/clubs.rs
+++ b/src-tauri/crates/ofm_core/src/generator/clubs.rs
@@ -353,6 +353,7 @@ pub fn generate_club_defs(config: &WorldGenConfig, rng: &mut impl Rng) -> Vec<Te
                 finance_range: Some([fin_lo, fin_hi]),
                 logo: None,
                 kit_pattern: None,
+                founded_year: None,
             });
         }
     }

--- a/src-tauri/crates/ofm_core/src/generator/definitions.rs
+++ b/src-tauri/crates/ofm_core/src/generator/definitions.rs
@@ -66,6 +66,9 @@ pub struct TeamDef {
     /// Kit jersey pattern (Solid, Stripes, Hoops, HalfAndHalf, Diagonal).
     #[serde(default, alias = "kit_pattern")]
     pub kit_pattern: Option<String>,
+    /// Year the team was founded. If not provided, will be randomly generated.
+    #[serde(default)]
+    pub founded_year: Option<u32>,
 }
 
 fn default_play_style() -> String {
@@ -142,6 +145,7 @@ pub(super) fn default_teams_definition() -> TeamsDefinition {
                 finance_range: Some([500_000, 10_000_000]),
                 logo: None,
                 kit_pattern: None,
+                founded_year: None,
             })
             .collect(),
     }

--- a/src-tauri/crates/ofm_core/src/generator/mod.rs
+++ b/src-tauri/crates/ofm_core/src/generator/mod.rs
@@ -529,7 +529,7 @@ fn build_team(tdef: &TeamDef, rng: &mut impl rand::Rng) -> domain::team::Team {
     team.reputation = rng.random_range(rep_range[0]..rep_range[1]);
     team.wage_budget = (team.finance as f64 * 0.06) as i64;
     team.transfer_budget = (team.finance as f64 * 0.15) as i64;
-    team.founded_year = rng.random_range(1880..1960);
+    team.founded_year = tdef.founded_year.unwrap_or(rng.random_range(1880..1960));
     team.colors = TeamColors {
         primary: tdef.colors.primary.clone(),
         secondary: tdef.colors.secondary.clone(),

--- a/src-tauri/src/commands/package_editor.rs
+++ b/src-tauri/src/commands/package_editor.rs
@@ -268,6 +268,7 @@ mod tests {
             finance_range: None,
             logo: None,
             kit_pattern: None,
+            founded_year: None,
         }];
 
         // Player WITH explicit attributes — exercises camelCase serde mapping and Position round-trip

--- a/src/components/menu/PackageEditor/TeamForm.tsx
+++ b/src/components/menu/PackageEditor/TeamForm.tsx
@@ -38,8 +38,8 @@ export function TeamForm({ editingTeam, editingTeamIndex, isBusy, projectDir, on
     setRepMax(editingTeam.reputationRange?.[1]?.toString() ?? "");
     setFinMin(editingTeam.financeRange?.[0]?.toString() ?? "");
     setFinMax(editingTeam.financeRange?.[1]?.toString() ?? "");
-  // Sync only when the selected entity changes, not on every field edit
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Sync only when the selected entity changes, not on every field edit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editingTeamIndex]);
 
   async function handlePickLogo() {
@@ -68,251 +68,257 @@ export function TeamForm({ editingTeam, editingTeamIndex, isBusy, projectDir, on
 
   return (
     <div className="flex gap-6 items-start">
-    <div className="flex-1 min-w-0 flex flex-col gap-4">
-      <div className="flex items-center gap-2 mb-2">
-        <button
-          onClick={onBack}
-          className="text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-navy-600"
-        >
-          <ArrowLeft className="w-5 h-5" />
-        </button>
-        <h2 className="text-xl font-heading font-bold uppercase tracking-wide text-gray-900 dark:text-white">
-          {editingTeamIndex === null
-            ? t("worldEditor.addTeam")
-            : t("worldEditor.editTeam")}
-        </h2>
-      </div>
+      <div className="flex-1 min-w-0 flex flex-col gap-4">
+        <div className="flex items-center gap-2 mb-2">
+          <button
+            onClick={onBack}
+            className="text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-navy-600"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </button>
+          <h2 className="text-xl font-heading font-bold uppercase tracking-wide text-gray-900 dark:text-white">
+            {editingTeamIndex === null
+              ? t("worldEditor.addTeam")
+              : t("worldEditor.editTeam")}
+          </h2>
+        </div>
 
-      <div className="flex flex-col gap-3">
-        <LabeledInput
-          label={t("worldEditor.teamId")}
-          value={editingTeam.id}
-          onChange={(v) => {
-            setIdAutoMode(false);
-            updateField("id", v);
-          }}
-          placeholder="man-utd"
-          help={t("worldEditor.help.teamId")}
-        />
-        <LabeledInput
-          label={t("worldEditor.teamName")}
-          value={editingTeam.name}
-          onChange={handleNameChange}
-        />
-        <LabeledInput
-          label={t("worldEditor.teamShortName")}
-          value={editingTeam.shortName}
-          onChange={(v) => updateField("shortName", v)}
-        />
+        <div className="flex flex-col gap-3">
+          <LabeledInput
+            label={t("worldEditor.teamId")}
+            value={editingTeam.id}
+            onChange={(v) => {
+              setIdAutoMode(false);
+              updateField("id", v);
+            }}
+            placeholder="man-utd"
+            help={t("worldEditor.help.teamId")}
+          />
+          <LabeledInput
+            label={t("worldEditor.teamName")}
+            value={editingTeam.name}
+            onChange={handleNameChange}
+          />
+          <LabeledInput
+            label={t("worldEditor.teamShortName")}
+            value={editingTeam.shortName}
+            onChange={(v) => updateField("shortName", v)}
+          />
 
-        {projectDir && (
-          <div className="flex flex-col gap-1">
-            <label className={labelClass}>{t("worldEditor.teamLogo")}</label>
-            <div className="flex items-center gap-3">
-              {logoDataUrl ? (
-                <img src={logoDataUrl} alt="" className="w-12 h-12 rounded-lg object-contain border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 flex-shrink-0" />
-              ) : (
-                <div className="w-12 h-12 rounded-lg border border-dashed border-gray-300 dark:border-navy-600 bg-gray-50 dark:bg-navy-700 flex items-center justify-center flex-shrink-0">
-                  <ImagePlus className="w-5 h-5 text-gray-300 dark:text-navy-500" />
-                </div>
-              )}
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => { void handlePickLogo(); }}
-                  className="px-3 py-1.5 text-xs font-heading font-bold uppercase tracking-wide rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-navy-600 transition"
-                >
-                  {t("worldEditor.chooseLogo")}
-                </button>
-                {editingTeam.logo && (
+          {projectDir && (
+            <div className="flex flex-col gap-1">
+              <label className={labelClass}>{t("worldEditor.teamLogo")}</label>
+              <div className="flex items-center gap-3">
+                {logoDataUrl ? (
+                  <img src={logoDataUrl} alt="" className="w-12 h-12 rounded-lg object-contain border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 flex-shrink-0" />
+                ) : (
+                  <div className="w-12 h-12 rounded-lg border border-dashed border-gray-300 dark:border-navy-600 bg-gray-50 dark:bg-navy-700 flex items-center justify-center flex-shrink-0">
+                    <ImagePlus className="w-5 h-5 text-gray-300 dark:text-navy-500" />
+                  </div>
+                )}
+                <div className="flex gap-2">
                   <button
                     type="button"
-                    onClick={() => { updateField("logo", null); }}
-                    className="px-2 py-1.5 text-xs rounded-lg border border-gray-200 dark:border-navy-600 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition"
+                    onClick={() => { void handlePickLogo(); }}
+                    className="px-3 py-1.5 text-xs font-heading font-bold uppercase tracking-wide rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-navy-600 transition"
                   >
-                    <X className="w-3.5 h-3.5" />
+                    {t("worldEditor.chooseLogo")}
                   </button>
-                )}
+                  {editingTeam.logo && (
+                    <button
+                      type="button"
+                      onClick={() => { updateField("logo", null); }}
+                      className="px-2 py-1.5 text-xs rounded-lg border border-gray-200 dark:border-navy-600 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <LabeledInput
+            label={t("worldEditor.teamFoundedYear")}
+            type="number"
+            value={editingTeam.foundedYear?.toString() ?? ""}
+            onChange={(v) => {
+              if (!v) return updateField("foundedYear", null);
+              const year = Number(v);
+              if (Number.isInteger(year) && year >= 0 && year <= 0xffffffff) {
+                updateField("foundedYear", year);
+              }
+            }}
+            placeholder="e.g. 1892"
+          />
+          <LabeledInput
+            label={t("worldEditor.teamCity")}
+            value={editingTeam.city}
+            onChange={(v) => updateField("city", v)}
+          />
+          <CountryCombobox
+            label={t("worldEditor.teamCountry")}
+            value={editingTeam.country}
+            onChange={(v) => updateField("country", v)}
+          />
+          <LabeledSelect
+            label={t("worldEditor.teamPlayStyle")}
+            value={editingTeam.playStyle}
+            options={PLAY_STYLES}
+            onChange={(v) => updateField("playStyle", v)}
+          />
+          <LabeledInput
+            label={t("worldEditor.teamStadium")}
+            value={editingTeam.stadiumName}
+            onChange={(v) => updateField("stadiumName", v)}
+          />
+
+          <div className="flex gap-3">
+            <div className="flex flex-col gap-1 flex-1">
+              <label className="text-[10px] font-heading font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+                {t("worldEditor.teamPrimaryColor")}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={/^#[0-9a-fA-F]{6}$/.test(editingTeam.colors.primary) ? editingTeam.colors.primary : "#000000"}
+                  onChange={(e) =>
+                    updateField("colors", { ...editingTeam.colors, primary: e.target.value })
+                  }
+                  className="w-9 h-9 rounded-lg border border-gray-200 dark:border-navy-600 cursor-pointer p-0.5 bg-white dark:bg-navy-700 flex-shrink-0"
+                />
+                <input
+                  type="text"
+                  value={editingTeam.colors.primary}
+                  onChange={(e) =>
+                    updateField("colors", { ...editingTeam.colors, primary: e.target.value })
+                  }
+                  className="flex-1 rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400 transition font-mono"
+                  placeholder="#cc0000"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1 flex-1">
+              <label className="text-[10px] font-heading font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+                {t("worldEditor.teamSecondaryColor")}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={/^#[0-9a-fA-F]{6}$/.test(editingTeam.colors.secondary) ? editingTeam.colors.secondary : "#ffffff"}
+                  onChange={(e) =>
+                    updateField("colors", { ...editingTeam.colors, secondary: e.target.value })
+                  }
+                  className="w-9 h-9 rounded-lg border border-gray-200 dark:border-navy-600 cursor-pointer p-0.5 bg-white dark:bg-navy-700 flex-shrink-0"
+                />
+                <input
+                  type="text"
+                  value={editingTeam.colors.secondary}
+                  onChange={(e) =>
+                    updateField("colors", { ...editingTeam.colors, secondary: e.target.value })
+                  }
+                  className="flex-1 rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400 transition font-mono"
+                  placeholder="#ffffff"
+                />
               </div>
             </div>
           </div>
-        )}
 
-        <LabeledInput
-          label={t("worldEditor.teamFoundedYear")}
-          type="number"
-          value={editingTeam.foundedYear?.toString() ?? ""}
-          onChange={(v) => updateField("foundedYear", v ? parseInt(v, 10) : null)}
-          placeholder="e.g. 1892"
-        />
-        <LabeledInput
-          label={t("worldEditor.teamCity")}
-          value={editingTeam.city}
-          onChange={(v) => updateField("city", v)}
-        />
-        <CountryCombobox
-          label={t("worldEditor.teamCountry")}
-          value={editingTeam.country}
-          onChange={(v) => updateField("country", v)}
-        />
-        <LabeledSelect
-          label={t("worldEditor.teamPlayStyle")}
-          value={editingTeam.playStyle}
-          options={PLAY_STYLES}
-          onChange={(v) => updateField("playStyle", v)}
-        />
-        <LabeledInput
-          label={t("worldEditor.teamStadium")}
-          value={editingTeam.stadiumName}
-          onChange={(v) => updateField("stadiumName", v)}
-        />
-
-        <div className="flex gap-3">
-          <div className="flex flex-col gap-1 flex-1">
-            <label className="text-[10px] font-heading font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
-              {t("worldEditor.teamPrimaryColor")}
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="color"
-                value={/^#[0-9a-fA-F]{6}$/.test(editingTeam.colors.primary) ? editingTeam.colors.primary : "#000000"}
-                onChange={(e) =>
-                  updateField("colors", { ...editingTeam.colors, primary: e.target.value })
-                }
-                className="w-9 h-9 rounded-lg border border-gray-200 dark:border-navy-600 cursor-pointer p-0.5 bg-white dark:bg-navy-700 flex-shrink-0"
-              />
-              <input
-                type="text"
-                value={editingTeam.colors.primary}
-                onChange={(e) =>
-                  updateField("colors", { ...editingTeam.colors, primary: e.target.value })
-                }
-                className="flex-1 rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400 transition font-mono"
-                placeholder="#cc0000"
-              />
-            </div>
-          </div>
-          <div className="flex flex-col gap-1 flex-1">
-            <label className="text-[10px] font-heading font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
-              {t("worldEditor.teamSecondaryColor")}
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="color"
-                value={/^#[0-9a-fA-F]{6}$/.test(editingTeam.colors.secondary) ? editingTeam.colors.secondary : "#ffffff"}
-                onChange={(e) =>
-                  updateField("colors", { ...editingTeam.colors, secondary: e.target.value })
-                }
-                className="w-9 h-9 rounded-lg border border-gray-200 dark:border-navy-600 cursor-pointer p-0.5 bg-white dark:bg-navy-700 flex-shrink-0"
-              />
-              <input
-                type="text"
-                value={editingTeam.colors.secondary}
-                onChange={(e) =>
-                  updateField("colors", { ...editingTeam.colors, secondary: e.target.value })
-                }
-                className="flex-1 rounded-lg border border-gray-200 dark:border-navy-600 bg-white dark:bg-navy-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-400 transition font-mono"
-                placeholder="#ffffff"
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Kit pattern selector */}
-        <div className="flex flex-col gap-1.5">
-          <label className={labelClass}>{t("worldEditor.teamKitPattern")}</label>
-          <div className="flex gap-2 flex-wrap">
-            {KIT_PATTERNS.map((pattern) => {
-              const isSelected = (editingTeam.kitPattern ?? "Solid") === pattern;
-              return (
-                <button
-                  key={pattern}
-                  type="button"
-                  onClick={() => updateField("kitPattern", pattern)}
-                  title={pattern}
+          {/* Kit pattern selector */}
+          <div className="flex flex-col gap-1.5">
+            <label className={labelClass}>{t("worldEditor.teamKitPattern")}</label>
+            <div className="flex gap-2 flex-wrap">
+              {KIT_PATTERNS.map((pattern) => {
+                const isSelected = (editingTeam.kitPattern ?? "Solid") === pattern;
+                return (
+                  <button
+                    key={pattern}
+                    type="button"
+                    onClick={() => updateField("kitPattern", pattern)}
+                    title={pattern}
                   className={`flex flex-col items-center gap-1 p-2 rounded-xl border transition-all ${
                     isSelected
-                      ? "border-primary-400 dark:border-primary-500 bg-primary-50 dark:bg-primary-500/10"
-                      : "border-gray-200 dark:border-navy-600 hover:border-gray-300 dark:hover:border-navy-500"
-                  }`}
-                >
-                  <JerseyIcon
-                    primaryColor={editingTeam.colors.primary || "#cc0000"}
-                    secondaryColor={editingTeam.colors.secondary || "#ffffff"}
-                    pattern={pattern}
-                    size="sm"
-                  />
-                  <span className="text-[9px] font-heading font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    {pattern === "HalfAndHalf" ? "½+½" : pattern}
-                  </span>
-                </button>
-              );
-            })}
+                        ? "border-primary-400 dark:border-primary-500 bg-primary-50 dark:bg-primary-500/10"
+                        : "border-gray-200 dark:border-navy-600 hover:border-gray-300 dark:hover:border-navy-500"
+                      }`}
+                  >
+                    <JerseyIcon
+                      primaryColor={editingTeam.colors.primary || "#cc0000"}
+                      secondaryColor={editingTeam.colors.secondary || "#ffffff"}
+                      pattern={pattern}
+                      size="sm"
+                    />
+                    <span className="text-[9px] font-heading font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      {pattern === "HalfAndHalf" ? "½+½" : pattern}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="grid grid-cols-2 gap-3">
+              <LabeledInput
+                label={t("worldEditor.teamRepMin")}
+                value={repMin}
+                type="number"
+                help={t("worldEditor.help.teamReputationRange")}
+                onChange={(v) => {
+                  setRepMin(v);
+                  updateField("reputationRange", makeRange(parseRangeBound(v), parseRangeBound(repMax)));
+                }}
+              />
+              <LabeledInput
+                label={t("worldEditor.teamRepMax")}
+                value={repMax}
+                type="number"
+                onChange={(v) => {
+                  setRepMax(v);
+                  updateField("reputationRange", makeRange(parseRangeBound(repMin), parseRangeBound(v)));
+                }}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <LabeledInput
+                label={t("worldEditor.teamFinMin")}
+                value={finMin}
+                type="number"
+                help={t("worldEditor.help.teamFinanceRange")}
+                onChange={(v) => {
+                  setFinMin(v);
+                  updateField("financeRange", makeRange(parseRangeBound(v), parseRangeBound(finMax)));
+                }}
+              />
+              <LabeledInput
+                label={t("worldEditor.teamFinMax")}
+                value={finMax}
+                type="number"
+                onChange={(v) => {
+                  setFinMax(v);
+                  updateField("financeRange", makeRange(parseRangeBound(finMin), parseRangeBound(v)));
+                }}
+              />
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <div className="grid grid-cols-2 gap-3">
-            <LabeledInput
-              label={t("worldEditor.teamRepMin")}
-              value={repMin}
-              type="number"
-              help={t("worldEditor.help.teamReputationRange")}
-              onChange={(v) => {
-                setRepMin(v);
-                updateField("reputationRange", makeRange(parseRangeBound(v), parseRangeBound(repMax)));
-              }}
-            />
-            <LabeledInput
-              label={t("worldEditor.teamRepMax")}
-              value={repMax}
-              type="number"
-              onChange={(v) => {
-                setRepMax(v);
-                updateField("reputationRange", makeRange(parseRangeBound(repMin), parseRangeBound(v)));
-              }}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <LabeledInput
-              label={t("worldEditor.teamFinMin")}
-              value={finMin}
-              type="number"
-              help={t("worldEditor.help.teamFinanceRange")}
-              onChange={(v) => {
-                setFinMin(v);
-                updateField("financeRange", makeRange(parseRangeBound(v), parseRangeBound(finMax)));
-              }}
-            />
-            <LabeledInput
-              label={t("worldEditor.teamFinMax")}
-              value={finMax}
-              type="number"
-              onChange={(v) => {
-                setFinMax(v);
-                updateField("financeRange", makeRange(parseRangeBound(finMin), parseRangeBound(v)));
-              }}
-            />
-          </div>
-        </div>
+        <button
+          onClick={onSave}
+          disabled={isBusy || !editingTeam.id || !editingTeam.name || !editingTeam.city || !editingTeam.country}
+          className="w-full py-3 bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white rounded-xl font-heading font-bold uppercase tracking-wide transition-all disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {isBusy ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <CheckCircle className="w-4 h-4" />
+          )}
+          {t("worldEditor.saveTeam")}
+        </button>
       </div>
-
-      <button
-        onClick={onSave}
-        disabled={isBusy || !editingTeam.id || !editingTeam.name || !editingTeam.city || !editingTeam.country}
-        className="w-full py-3 bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white rounded-xl font-heading font-bold uppercase tracking-wide transition-all disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-      >
-        {isBusy ? (
-          <Loader2 className="w-4 h-4 animate-spin" />
-        ) : (
-          <CheckCircle className="w-4 h-4" />
-        )}
-        {t("worldEditor.saveTeam")}
-      </button>
-    </div>
-    <div className="w-52 flex-shrink-0 sticky top-0">
-      <TeamPreviewCard team={editingTeam} logoDataUrl={logoDataUrl} />
-    </div>
+      <div className="w-52 flex-shrink-0 sticky top-0">
+        <TeamPreviewCard team={editingTeam} logoDataUrl={logoDataUrl} />
+      </div>
     </div>
   );
 }

--- a/src/components/menu/PackageEditor/TeamForm.tsx
+++ b/src/components/menu/PackageEditor/TeamForm.tsx
@@ -139,6 +139,13 @@ export function TeamForm({ editingTeam, editingTeamIndex, isBusy, projectDir, on
         )}
 
         <LabeledInput
+          label={t("worldEditor.teamFoundedYear")}
+          type="number"
+          value={editingTeam.foundedYear?.toString() ?? ""}
+          onChange={(v) => updateField("foundedYear", v ? parseInt(v, 10) : null)}
+          placeholder="e.g. 1892"
+        />
+        <LabeledInput
           label={t("worldEditor.teamCity")}
           value={editingTeam.city}
           onChange={(v) => updateField("city", v)}

--- a/src/components/menu/PackageEditor/TeamPreviewCard.tsx
+++ b/src/components/menu/PackageEditor/TeamPreviewCard.tsx
@@ -65,11 +65,19 @@ export function TeamPreviewCard({ team, logoDataUrl }: TeamPreviewCardProps) {
           <p className="font-heading font-bold text-sm uppercase tracking-wide text-gray-900 dark:text-white leading-tight">
             {team.name || <span className="text-gray-400 italic">New Team</span>}
           </p>
-          {team.shortName && (
-            <p className="text-[10px] text-gray-400 dark:text-gray-500 font-mono mt-0.5">
-              {team.shortName}
-            </p>
-          )}
+          
+          <div className="flex items-center justify-between text-[11px]">
+            {team.shortName && (
+              <p className="text-[10px] text-gray-400 dark:text-gray-500 font-mono mt-0.5">
+                {team.shortName}
+              </p>
+            )}
+            {team.foundedYear && (
+              <p className="text-[10px] text-gray-400 dark:text-gray-500 font-mono mt-0.5">
+                {t("teams.est")} {team.foundedYear}
+              </p>
+            )}
+          </div>
         </div>
 
         {/* Colors + Jersey */}

--- a/src/components/menu/PackageEditor/TeamPreviewCard.tsx
+++ b/src/components/menu/PackageEditor/TeamPreviewCard.tsx
@@ -72,7 +72,7 @@ export function TeamPreviewCard({ team, logoDataUrl }: TeamPreviewCardProps) {
                 {team.shortName}
               </p>
             )}
-            {team.foundedYear && (
+            {team.foundedYear != null && (
               <p className="text-[10px] text-gray-400 dark:text-gray-500 font-mono mt-0.5">
                 {t("teams.est")} {team.foundedYear}
               </p>

--- a/src/components/menu/PackageEditor/helpers.ts
+++ b/src/components/menu/PackageEditor/helpers.ts
@@ -117,6 +117,7 @@ export function emptyTeam(): TeamDef {
     financeRange: null,
     logo: null,
     kitPattern: null,
+    foundedYear: null,
   };
 }
 

--- a/src/components/menu/PackageEditor/sampleData.ts
+++ b/src/components/menu/PackageEditor/sampleData.ts
@@ -53,6 +53,7 @@ export const MINI_LEAGUE_SAMPLE: SamplePackage = {
       financeRange: [800000, 3000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1987,
     },
     {
       id: "westbrook-united",
@@ -67,6 +68,7 @@ export const MINI_LEAGUE_SAMPLE: SamplePackage = {
       financeRange: [600000, 2500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1996,
     },
     {
       id: "eastgate-city",
@@ -81,6 +83,7 @@ export const MINI_LEAGUE_SAMPLE: SamplePackage = {
       financeRange: [500000, 2000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1991,
     },
     {
       id: "southfield-rovers",
@@ -95,6 +98,7 @@ export const MINI_LEAGUE_SAMPLE: SamplePackage = {
       financeRange: [400000, 1500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1996,
     },
   ],
   players: [] as PlayerDef[],
@@ -149,6 +153,7 @@ export const IBERIA_MINI_SAMPLE: SamplePackage = {
       financeRange: [2000000, 8000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1978,
     },
     {
       id: "puerto-fc",
@@ -163,6 +168,7 @@ export const IBERIA_MINI_SAMPLE: SamplePackage = {
       financeRange: [1500000, 6000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1995,
     },
     {
       id: "real-camino",
@@ -177,6 +183,7 @@ export const IBERIA_MINI_SAMPLE: SamplePackage = {
       financeRange: [800000, 3500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1988,
     },
     {
       id: "atletico-sur",
@@ -191,6 +198,7 @@ export const IBERIA_MINI_SAMPLE: SamplePackage = {
       financeRange: [700000, 2500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1976,
     },
   ],
   players: [] as PlayerDef[],
@@ -250,6 +258,7 @@ export const SOUTH_AMERICAN_CUP_SAMPLE: SamplePackage = {
       financeRange: [1000000, 4000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1994,
     },
     {
       id: "copa-verde",
@@ -264,6 +273,7 @@ export const SOUTH_AMERICAN_CUP_SAMPLE: SamplePackage = {
       financeRange: [900000, 3500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1989,
     },
     {
       id: "la-celeste-fc",
@@ -278,6 +288,7 @@ export const SOUTH_AMERICAN_CUP_SAMPLE: SamplePackage = {
       financeRange: [700000, 2500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1976,
     },
     {
       id: "la-roja-fc",
@@ -292,6 +303,7 @@ export const SOUTH_AMERICAN_CUP_SAMPLE: SamplePackage = {
       financeRange: [600000, 2000000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1985,
     },
   ],
   players: [] as PlayerDef[],
@@ -349,6 +361,7 @@ export const ACADEMY_SHOWCASE_SAMPLE: SamplePackage = {
       financeRange: [900000, 3500000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1991,
     },
     {
       id: "rival-rovers",
@@ -363,6 +376,7 @@ export const ACADEMY_SHOWCASE_SAMPLE: SamplePackage = {
       financeRange: [700000, 2800000],
       logo: null,
       kitPattern: null,
+      foundedYear: 1988,
     },
   ],
   players: [

--- a/src/components/menu/PackageEditor/types.ts
+++ b/src/components/menu/PackageEditor/types.ts
@@ -20,6 +20,7 @@ export interface TeamDef {
   financeRange: [number, number] | null;
   logo: string | null;
   kitPattern: KitPattern | null;
+  foundedYear: number | null;
 }
 
 export interface WorldMetaDef {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3734,6 +3734,7 @@
     "teamKitPattern": "Vzor dresu",
     "teamPlayStyle": "Herední styl",
     "teamStadium": "Stadion",
+    "teamFoundedYear": "Založen",
     "teamRepMin": "Min. reputace",
     "teamRepMax": "Max. reputace",
     "teamFinMin": "Min. rozpočet",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3737,7 +3737,7 @@
     "teamKitPattern": "Trikotstil",
     "teamPlayStyle": "Spielstil",
     "teamStadium": "Stadionname",
-    "teamFoundedYear": "Grundjahr",
+    "teamFoundedYear": "Gründungsjahr",
     "teamRepMin": "Min. Ansehen",
     "teamRepMax": "Max. Ansehen",
     "teamFinMin": "Min. Budget",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3737,6 +3737,7 @@
     "teamKitPattern": "Trikotstil",
     "teamPlayStyle": "Spielstil",
     "teamStadium": "Stadionname",
+    "teamFoundedYear": "Grundjahr",
     "teamRepMin": "Min. Ansehen",
     "teamRepMax": "Max. Ansehen",
     "teamFinMin": "Min. Budget",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3733,6 +3733,7 @@
     "teamKitPattern": "Kit Pattern",
     "teamPlayStyle": "Play Style",
     "teamStadium": "Stadium",
+    "teamFoundedYear": "Founded Year",
     "teamRepMin": "Min Reputation",
     "teamRepMax": "Max Reputation",
     "teamFinMin": "Min Budget",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3769,6 +3769,7 @@
     "teamKitPattern": "Diseño de Camiseta",
     "teamPlayStyle": "Estilo de Juego",
     "teamStadium": "Estadio",
+    "teamFoundedYear": "Año de Fundación",
     "teamRepMin": "Reputación Mínima",
     "teamRepMax": "Reputación Máxima",
     "teamFinMin": "Presupuesto Mínimo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3737,6 +3737,7 @@
     "teamKitPattern": "Motif de Maillot",
     "teamPlayStyle": "Style de Jeu",
     "teamStadium": "Stade",
+    "teamFoundedYear": "Année de Création",
     "teamRepMin": "Réputation Min.",
     "teamRepMax": "Réputation Max.",
     "teamFinMin": "Budget Min.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3737,6 +3737,7 @@
     "teamKitPattern": "Motivo Maglia",
     "teamPlayStyle": "Stile di Gioco",
     "teamStadium": "Stadio",
+    "teamFoundedYear": "Anno di Fondazione",
     "teamRepMin": "Reputazione Min.",
     "teamRepMax": "Reputazione Max.",
     "teamFinMin": "Budget Min.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3737,6 +3737,7 @@
     "teamKitPattern": "Padrão do Uniforme",
     "teamPlayStyle": "Estilo de Jogo",
     "teamStadium": "Estádio",
+    "teamFoundedYear": "Ano de Fundação",
     "teamRepMin": "Reputação Mín.",
     "teamRepMax": "Reputação Máx.",
     "teamFinMin": "Orçamento Mín.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -3737,6 +3737,7 @@
     "teamKitPattern": "Padrão do Equipamento",
     "teamPlayStyle": "Estilo de Jogo",
     "teamStadium": "Estádio",
+    "teamFoundedYear": "Ano de Fundação",
     "teamRepMin": "Reputação Mín.",
     "teamRepMax": "Reputação Máx.",
     "teamFinMin": "Orçamento Mín.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -3733,6 +3733,7 @@
     "teamKitPattern": "Узор формы",
     "teamPlayStyle": "Стиль игры",
     "teamStadium": "Стадион",
+    "teamFoundedYear": "Год основания",
     "teamRepMin": "Репутация мин.",
     "teamRepMax": "Репутация макс.",
     "teamFinMin": "Бюджет мин.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -3733,6 +3733,7 @@
     "teamKitPattern": "Forma Deseni",
     "teamPlayStyle": "Oyun Tarzı",
     "teamStadium": "Stadyum",
+    "teamFoundedYear": "Kurulma Yılı",
     "teamRepMin": "En Düşük İtibar",
     "teamRepMax": "En Yüksek İtibar",
     "teamFinMin": "En Düşük Bütçe",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3734,6 +3734,7 @@
     "teamKitPattern": "球衣图案",
     "teamPlayStyle": "打法风格",
     "teamStadium": "球场",
+    "teamFoundedYear": "成立年份",
     "teamRepMin": "声誉最小值",
     "teamRepMax": "声誉最大值",
     "teamFinMin": "预算最小值",


### PR DESCRIPTION
Allowed adding the teams founding year when editing the team in the world editor.

 - Team editing screen in the world editor
<img width="564" height="236" alt="Screenshot 2026-07-12 171638" src="https://github.com/user-attachments/assets/64300ebc-5a5f-4f07-b6d2-9a8c34339e5c" />
<img width="564" height="235" alt="Screenshot 2026-07-12 171646" src="https://github.com/user-attachments/assets/a4dbb019-e472-407b-bb67-dce78f449168" />

<br><br>

 - In-game team screen
<img width="452" height="139" alt="Screenshot 2026-07-12 003236" src="https://github.com/user-attachments/assets/a76a11d7-1181-46ae-a7aa-105296b5d8a3" />

<br><br>

- If the year is not specified on the team editing screen in the world editor, a random year will be used (as previously implemented).
<img width="401" height="120" alt="Screenshot 2026-07-12 003248" src="https://github.com/user-attachments/assets/08a91953-e39d-4265-ac2b-7425e6271c0e" />

<br><br>

 - Founding year added to the team preview in the world editor, if the founding year is provided.
<img width="214" height="332" alt="Screenshot 2026-07-13 232316" src="https://github.com/user-attachments/assets/9a5ff485-43cb-4974-99c5-2149c43c0428" />

Closes https://github.com/openfootmanager/openfootmanager/issues/358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an optional **Founded Year** field to team editing.
  * The value is stored with team data and shown on team preview cards when present.
  * If omitted, world generation will assign a random founding year between **1880–1959**.
  * Added localized UI labels for the new field across supported languages.
* **Documentation**
  * Updated modding and schema references, including world-generation behavior and example data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->