### PR TITLE
chore(templates): drop the blanket "beta" label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: "\U0001F41B Bug Report (English)"
 description: "Report a bug or crash in English"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_de.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_de.yml
@@ -1,6 +1,6 @@
 name: "🐛 Bug melden (Deutsch)"
 description: "Melde einen Bug oder Absturz auf Deutsch"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_es.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_es.yml
@@ -1,6 +1,6 @@
 name: "🐛 Reporte de Bug (Español)"
 description: "Reporta un bug o crash en español"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_fr.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_fr.yml
@@ -1,6 +1,6 @@
 name: "🐛 Rapport de Bug (Français)"
 description: "Signaler un bug ou un crash en français"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_it.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_it.yml
@@ -1,6 +1,6 @@
 name: "🐛 Segnalazione Bug (Italiano)"
 description: "Segnala un bug o un crash in italiano"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_pt.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pt.yml
@@ -1,6 +1,6 @@
 name: "🐛 Relatório de Bug (Português PT)"
 description: "Reportar um bug ou crash em português europeu"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_ptbr.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_ptbr.yml
@@ -1,6 +1,6 @@
 name: "🐛 Relatório de Bug (Português BR)"
 description: "Reporte um bug ou travamento em português do Brasil"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_zh_cn.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_zh_cn.yml
@@ -1,6 +1,6 @@
 name: "🐛 Bug 报告（简体中文）"
 description: "用简体中文报告 bug 或崩溃问题"
-labels: ["bug", "beta"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,6 +1,6 @@
 name: "\U0001F4AC Feedback / Suggestion (English)"
 description: "Share feedback or suggest improvements in English"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_de.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_de.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Vorschlag (Deutsch)"
 description: "Teile Feedback oder Verbesserungsvorschläge auf Deutsch"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_es.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_es.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Sugerencia (Español)"
 description: "Comparte feedback o sugerencias en español"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_fr.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_fr.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Suggestion (Français)"
 description: "Partager un retour ou une suggestion en français"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_it.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_it.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Suggerimento (Italiano)"
 description: "Condividi feedback o suggerimenti in italiano"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_pt.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_pt.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Sugestão (Português PT)"
 description: "Partilha feedback ou sugestões em português europeu"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_ptbr.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_ptbr.yml
@@ -1,6 +1,6 @@
 name: "💬 Feedback / Sugestão (Português BR)"
 description: "Compartilhe feedback ou sugestões em português do Brasil"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback_zh_cn.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_zh_cn.yml
@@ -1,6 +1,6 @@
 name: "💬 反馈 / 建议（简体中文）"
 description: "用简体中文分享反馈或改进建议"
-labels: ["feedback", "beta"]
+labels: ["feedback"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report.yml
+++ b/.github/ISSUE_TEMPLATE/session_report.yml
@@ -1,6 +1,6 @@
 name: "\U0001F3AE Session Report (English)"
 description: "Share a summary of your play session in English"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_de.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_de.yml
@@ -1,6 +1,6 @@
 name: "🎮 Sitzungsbericht (Deutsch)"
 description: "Teile eine Zusammenfassung deiner Spielsitzung auf Deutsch"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_es.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_es.yml
@@ -1,6 +1,6 @@
 name: "🎮 Reporte de Sesión (Español)"
 description: "Comparte un resumen de tu sesión de juego en español"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_fr.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_fr.yml
@@ -1,6 +1,6 @@
 name: "🎮 Rapport de Session (Français)"
 description: "Partager un résumé de votre session de jeu en français"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_it.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_it.yml
@@ -1,6 +1,6 @@
 name: "🎮 Resoconto di Sessione (Italiano)"
 description: "Condividi un riepilogo della tua sessione di gioco in italiano"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_pt.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_pt.yml
@@ -1,6 +1,6 @@
 name: "🎮 Relatório de Sessão (Português PT)"
 description: "Partilha um resumo da tua sessão de jogo em português europeu"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_ptbr.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_ptbr.yml
@@ -1,6 +1,6 @@
 name: "🎮 Relatório de Sessão (Português BR)"
 description: "Compartilhe um resumo da sua sessão de jogo em português do Brasil"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/session_report_zh_cn.yml
+++ b/.github/ISSUE_TEMPLATE/session_report_zh_cn.yml
@@ -1,6 +1,6 @@
 name: "🎮 游戏会话报告（简体中文）"
 description: "用简体中文分享一次游玩会话的总结"
-labels: ["session-report", "beta"]
+labels: ["session-report"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What
Removes the `beta` label from all issue templates (`.github/ISSUE_TEMPLATE/*.yml`).

## Why
`beta` was declared on every template (bug, feedback, session-report), so it landed on 100% of new issues and carried no filtering value. GitHub also silently drops template labels that don't exist in the repo, and `beta` was never created — so it was a no-op regardless.

The `session-report` and `feedback` labels referenced by the templates are **kept** — they're genuinely useful for filtering. They also don't currently exist in the repo yet, so GitHub silently ignores them today.

## Ask for @sturdy-robot
Could you create these two labels in the repo? Once they exist the templates will apply them automatically — no further code change needed:
- `session-report` — player game-session reports (e.g. #332, #333)
- `feedback` — general player feedback

It'd also be worth backfilling `session-report` onto the existing reports #332 and #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `beta` label from bug report, feedback, and session report templates.
  * New submissions now receive only their relevant label: `bug`, `feedback`, or `session-report`.
  * Applied consistently across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->