### PR TITLE
fix(schedule): label friendly fixture groups as "Friendly" instead of league name

### DIFF
--- a/src/components/schedule/ScheduleTab.test.tsx
+++ b/src/components/schedule/ScheduleTab.test.tsx
@@ -37,6 +37,7 @@ vi.mock("react-i18next", () => ({
       if (key === "schedule.season") return `Season ${(params as Record<string, number>)?.number}`;
       if (key === "schedule.matchday")
         return `Matchday ${(params as Record<string, number>)?.number}`;
+      if (key === "season.friendly") return "Friendly";
       if (key === "common.team") return "Team";
       if (key === "common.viewTeam") return "View team";
       if (key === "common.played") return "P";
@@ -223,6 +224,27 @@ describe("ScheduleTab", () => {
     await waitFor(() => {
       expect(screen.getByText("Next match")).toBeInTheDocument();
     });
+  });
+
+  it("labels a friendly group as 'Friendly' instead of the league name", async () => {
+    const slice = makeSlice({
+      upcoming_groups: [
+        makeGroup({
+          key: "g-friendly",
+          competition: "Friendly",
+          matchday: 0,
+          fixtures: [{ id: "fix-friendly", matchday: 0, date: "2026-09-05", home_team_id: "team-1", home_team_name: "Alpha FC", away_team_id: "team-2", away_team_name: "Beta FC", competition: "Friendly", competition_id: "friendly-1", status: "Scheduled", result: null }],
+        }),
+      ],
+    });
+    mockedInvoke.mockResolvedValue(slice);
+
+    render(<ScheduleTab gameState={makeGameState(true)} onSelectTeam={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Friendly/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Premier League/)).not.toBeInTheDocument();
   });
 
   it("fixtures view shows all fixture rows from the slice", async () => {

--- a/src/components/schedule/ScheduleTab.test.tsx
+++ b/src/components/schedule/ScheduleTab.test.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 import type { FixtureData, GameStateData, TeamData } from "../../store/gameStore";
 import type { MatchdayGroup, ScheduleSlice } from "../../services/scheduleService";
+import { formatMatchDate } from "../../lib/dateFormatting";
 import ScheduleTab from "./ScheduleTab";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -242,7 +243,9 @@ describe("ScheduleTab", () => {
     render(<ScheduleTab gameState={makeGameState(true)} onSelectTeam={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Friendly/)).toBeInTheDocument();
+      expect(
+        screen.getByText(`Friendly – ${formatMatchDate("2026-09-05")}`),
+      ).toBeInTheDocument();
     });
     expect(screen.queryByText(/Premier League/)).not.toBeInTheDocument();
   });

--- a/src/components/schedule/ScheduleTab.tsx
+++ b/src/components/schedule/ScheduleTab.tsx
@@ -446,6 +446,9 @@ function groupLabel(
   if (group.competition === "PreseasonTournament") {
     return `${competitionName} – ${t("season.preseasonTournament", "Pre-season")} – ${formatMatchDate(group.date)}`;
   }
+  if (group.competition === "Friendly") {
+    return `${t("season.friendly", "Friendly")} – ${formatMatchDate(group.date)}`;
+  }
   return `${competitionName} – ${formatMatchDate(group.date)}`;
 }
 


### PR DESCRIPTION
Closes #368

## Summary
Pre-season friendlies in the Schedule tab fixtures list were labeled with the league's name (e.g. "Germany Second Division"), making them indistinguishable from league fixtures. `groupLabel()` in `ScheduleTab.tsx` only special-cased `"League"` and `"PreseasonTournament"`, so friendlies fell through to the competition-name fallback.

This adds a `"Friendly"` branch that renders the existing `season.friendly` translation (already used by `NextMatchDisplay` and `HomeNextOpponentCard`), producing `Friendly – <date>`.

## Changes
| File | Change |
|------|--------|
| `src/components/schedule/ScheduleTab.tsx` | Add `"Friendly"` branch to `groupLabel()` |
| `src/components/schedule/ScheduleTab.test.tsx` | Test asserting a friendly group renders "Friendly" and not the league name |

## Test plan
- `npx vitest run src/components/schedule` → 16 passed, 0 failed
- The new test fails on the previous code (label fell through to `Premier League – <date>`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Friendly fixtures now show a dedicated, translated “Friendly” label next to the matchday date.

* **Bug Fixes**
  * Friendly fixtures are no longer categorized under the “Premier League” competition label in the schedule UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->