### PR TITLE
fix(tauri): disable native drag-drop handler so HTML5 DnD works on Windows

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,14 +16,17 @@
         "width": 1280,
         "height": 800,
         "minWidth": 960,
-        "minHeight": 640
+        "minHeight": 640,
+        "dragDropEnabled": false
       }
     ],
     "security": {
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": ["$APPDATA/generated-player-portraits/**"]
+        "scope": [
+          "$APPDATA/generated-player-portraits/**"
+        ]
       }
     }
   },


### PR DESCRIPTION
Closes #375

## Summary
On Windows, WebView2 intercepts OS-level drag-and-drop when Tauri's window `dragDropEnabled` is left at its default (`true`), which breaks in-page HTML5 drag-and-drop. This made the Tactics/Squad pitch drag interactions (swap players, pitch ↔ bench) completely unusable on Windows: every drop target showed the "not allowed" cursor. The frontend DnD handlers themselves are correct, so the fix is config-only.

## Changes
| File | Change |
|------|--------|
| `src-tauri/tauri.conf.json` | Set `"dragDropEnabled": false` on the main window |

## Notes
- The repo has no `onDragDropEvent`/native file-drop usage (checked frontend and Rust crates), so disabling the native handler loses nothing.
- Linux/macOS behavior is unchanged; this only stops WebView2 from swallowing HTML5 DnD on Windows.

## Test plan
- Verified on Windows 11 (`npm run tauri dev`): before the change, dragging any player token showed the blocked cursor; after it, swapping players on the pitch and moving players between pitch and bench work as described by the in-game hint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled file drag-and-drop behavior in the main application window.
* **Chores**
  * Improved formatting of asset access configuration without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->