### PR TITLE
fix(tactics): disable no-op tactic save and show a saved confirmation cue

### DIFF
--- a/src/components/tactics/TacticsCommandBar.test.tsx
+++ b/src/components/tactics/TacticsCommandBar.test.tsx
@@ -1,0 +1,158 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TacticsCommandBar, {
+  type TacticsLibraryEntry,
+} from "./TacticsCommandBar";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === "string" ? fallback : key,
+    i18n: { language: "en" },
+  }),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const customTactic: TacticsLibraryEntry = {
+  description: "A custom tactic",
+  formation: "4-4-2",
+  id: "custom:1",
+  name: "My Tactic",
+  playStyle: "Balanced",
+  sourcePresetName: null,
+  type: "custom",
+};
+
+const presetTactic: TacticsLibraryEntry = {
+  description: "A preset tactic",
+  formation: "4-3-3",
+  id: "preset:balanced-control",
+  name: "Balanced Control",
+  playStyle: "Balanced",
+  sourcePresetName: null,
+  type: "preset",
+};
+
+function buildProps(
+  overrides: Partial<React.ComponentProps<typeof TacticsCommandBar>> = {},
+): React.ComponentProps<typeof TacticsCommandBar> {
+  return {
+    activeTactic: customTactic,
+    activePlayStyle: "Balanced",
+    formation: "4-4-2",
+    isDirty: false,
+    onCreateNew: vi.fn(),
+    onDuplicate: vi.fn(),
+    onFormationChange: vi.fn(),
+    onPlayStyleChange: vi.fn(),
+    onSave: vi.fn(),
+    onSelectTactic: vi.fn(),
+    tacticLibrary: [customTactic, presetTactic],
+    ...overrides,
+  };
+}
+
+function renderCommandBar(
+  overrides: Partial<React.ComponentProps<typeof TacticsCommandBar>> = {},
+) {
+  return render(<TacticsCommandBar {...buildProps(overrides)} />);
+}
+
+describe("TacticsCommandBar", () => {
+  it("disables the save button when the active custom tactic is already synced", () => {
+    renderCommandBar({ activeTactic: customTactic, isDirty: false });
+
+    expect(
+      screen.getByRole("button", { name: "tactics.updateTactic" }),
+    ).toBeDisabled();
+  });
+
+  it("enables the save button once the active custom tactic has unsaved changes", () => {
+    renderCommandBar({ activeTactic: customTactic, isDirty: true });
+
+    expect(
+      screen.getByRole("button", { name: "tactics.updateTactic" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps the save button enabled for a preset even when nothing changed", () => {
+    // Saving a preset always creates a new custom tactic, so it is never a
+    // no-op even when isDirty is false.
+    renderCommandBar({ activeTactic: presetTactic, isDirty: false });
+
+    expect(
+      screen.getByRole("button", { name: "tactics.saveAsTactic" }),
+    ).toBeEnabled();
+  });
+
+  it("shows a temporary Saved confirmation after a successful save click", () => {
+    vi.useFakeTimers();
+    const onSave = vi.fn();
+    const props = buildProps({ activeTactic: customTactic, isDirty: true, onSave });
+
+    const { rerender } = render(<TacticsCommandBar {...props} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "tactics.updateTactic" }),
+    );
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // A successful save syncs the stored tactic, so the parent re-renders
+    // with isDirty flipped back to false.
+    rerender(<TacticsCommandBar {...props} isDirty={false} />);
+
+    expect(
+      screen.getByRole("button", { name: "tactics.tacticSaved" }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: "tactics.updateTactic" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the Saved cue immediately when new edits make the tactic dirty again mid-cue", () => {
+    vi.useFakeTimers();
+    const onSave = vi.fn();
+    const props = buildProps({
+      activeTactic: customTactic,
+      isDirty: true,
+      onSave,
+    });
+
+    const { rerender } = render(<TacticsCommandBar {...props} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "tactics.updateTactic" }),
+    );
+
+    // The save synced the tactic — parent re-renders with isDirty: false —
+    // so the "Saved" cue becomes visible.
+    rerender(<TacticsCommandBar {...props} isDirty={false} />);
+    expect(
+      screen.getByRole("button", { name: "tactics.tacticSaved" }),
+    ).toBeInTheDocument();
+
+    // The user edits the tactic again before the 2s cue timeout fires.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender(<TacticsCommandBar {...props} isDirty />);
+
+    const saveButton = screen.getByRole("button", {
+      name: "tactics.updateTactic",
+    });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: "tactics.tacticSaved" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/tactics/TacticsCommandBar.tsx
+++ b/src/components/tactics/TacticsCommandBar.tsx
@@ -1,4 +1,5 @@
 import {
+  Check,
   Copy,
   Crosshair,
   Flag,
@@ -47,6 +48,8 @@ interface TacticsCommandBarProps {
   tacticLibrary: TacticsLibraryEntry[];
 }
 
+const SAVE_CUE_DURATION_MS = 2000;
+
 const PLAY_STYLES = [
   { id: "Balanced", icon: <Target className="h-3.5 w-3.5" /> },
   { id: "Attacking", icon: <Zap className="h-3.5 w-3.5" /> },
@@ -76,7 +79,9 @@ export default function TacticsCommandBar({
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [showSavedCue, setShowSavedCue] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const savedCueTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const filteredLibrary = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -107,6 +112,10 @@ export default function TacticsCommandBar({
     activeTactic.type === "custom"
       ? t("tactics.updateTactic")
       : t("tactics.saveAsTactic");
+  // Saving a synced custom tactic is a silent no-op — nothing has changed to
+  // persist. Presets stay enabled even when isDirty is false because saving
+  // there always creates a new custom tactic, which is an observable action.
+  const isSaveDisabled = activeTactic.type === "custom" && !isDirty;
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
@@ -118,6 +127,27 @@ export default function TacticsCommandBar({
     document.addEventListener("mousedown", handlePointerDown);
     return () => document.removeEventListener("mousedown", handlePointerDown);
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (savedCueTimeoutRef.current) {
+        clearTimeout(savedCueTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleSaveClick(): void {
+    onSave();
+    setShowSavedCue(true);
+
+    if (savedCueTimeoutRef.current) {
+      clearTimeout(savedCueTimeoutRef.current);
+    }
+
+    savedCueTimeoutRef.current = setTimeout(() => {
+      setShowSavedCue(false);
+    }, SAVE_CUE_DURATION_MS);
+  }
 
   return (
     <Card className="overflow-visible">
@@ -169,10 +199,12 @@ export default function TacticsCommandBar({
                 type="button"
                 variant="accent"
                 size="sm"
-                icon={<Save />}
-                onClick={onSave}
+                icon={showSavedCue && !isDirty ? <Check /> : <Save />}
+                onClick={handleSaveClick}
+                disabled={isSaveDisabled}
+                className="min-w-[9.5rem]"
               >
-                {saveLabel}
+                {showSavedCue && !isDirty ? t("tactics.tacticSaved") : saveLabel}
               </Button>
             </div>
           </div>

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -710,6 +710,7 @@
     "duplicateTactic": "Duplikovat",
     "saveAsTactic": "Uložit jako taktiku",
     "updateTactic": "Aktualizovat taktiku",
+    "tacticSaved": "Uloženo",
     "tacticName": "Název taktiky",
     "identitySummary": "Shrnutí identity",
     "synced": "Synchronizováno",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "Duplizieren",
     "saveAsTactic": "Als Taktik speichern",
     "updateTactic": "Taktik aktualisieren",
+    "tacticSaved": "Gespeichert",
     "tacticName": "Taktikname",
     "identitySummary": "Identitätsübersicht",
     "synced": "Synchronisiert",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -710,6 +710,7 @@
     "duplicateTactic": "Duplicate",
     "saveAsTactic": "Save as tactic",
     "updateTactic": "Update tactic",
+    "tacticSaved": "Saved",
     "tacticName": "Tactic name",
     "identitySummary": "Identity summary",
     "synced": "Synced",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -790,6 +790,7 @@
     "duplicateTactic": "Duplicar",
     "saveAsTactic": "Guardar como táctica",
     "updateTactic": "Actualizar táctica",
+    "tacticSaved": "Guardado",
     "tacticName": "Nombre de la táctica",
     "identitySummary": "Resumen de identidad",
     "synced": "Sincronizado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "Dupliquer",
     "saveAsTactic": "Enregistrer comme tactique",
     "updateTactic": "Mettre à jour la tactique",
+    "tacticSaved": "Enregistré",
     "tacticName": "Nom de la tactique",
     "identitySummary": "Résumé d'identité",
     "synced": "Synchronisé",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -777,6 +777,7 @@
     "duplicateTactic": "Duplica",
     "saveAsTactic": "Salva come tattica",
     "updateTactic": "Aggiorna tattica",
+    "tacticSaved": "Salvato",
     "tacticName": "Nome tattica",
     "identitySummary": "Riepilogo identità",
     "synced": "Sincronizzato",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "Duplicar",
     "saveAsTactic": "Salvar como tática",
     "updateTactic": "Atualizar tática",
+    "tacticSaved": "Salvo",
     "tacticName": "Nome da tática",
     "identitySummary": "Resumo de identidade",
     "synced": "Sincronizado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "Duplicar",
     "saveAsTactic": "Guardar como tática",
     "updateTactic": "Atualizar tática",
+    "tacticSaved": "Guardado",
     "tacticName": "Nome da tática",
     "identitySummary": "Resumo da identidade",
     "synced": "Sincronizado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "Дублировать",
     "saveAsTactic": "Сохранить как тактику",
     "updateTactic": "Обновить тактику",
+    "tacticSaved": "Сохранено",
     "tacticName": "Название тактики",
     "identitySummary": "Сводка идентичности",
     "synced": "Синхронизировано",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -710,6 +710,7 @@
     "duplicateTactic": "Çoğalt",
     "saveAsTactic": "Taktik olarak kaydet",
     "updateTactic": "Taktiği güncelle",
+    "tacticSaved": "Kaydedildi",
     "tacticName": "Taktik adı",
     "identitySummary": "Kimlik özeti",
     "synced": "Senkronize",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -758,6 +758,7 @@
     "duplicateTactic": "复制",
     "saveAsTactic": "保存为战术",
     "updateTactic": "更新战术",
+    "tacticSaved": "已保存",
     "tacticName": "战术名称",
     "identitySummary": "风格摘要",
     "synced": "已同步",


### PR DESCRIPTION
Closes #377

## Summary
The "Update tactic" button in the Tactics command bar was a silent no-op when the active custom tactic was already synced, and gave no success feedback when it did save. This PR makes the button honest:

- **Disabled when there is nothing to update**: `activeTactic.type === "custom" && !isDirty`. Presets stay enabled because "Save as tactic" always creates a new custom tactic, which is an observable action.
- **Success cue with no new infrastructure**: after a save click the button momentarily (2s) shows a check icon and a "Saved" label, then reverts. The cue also gates on `!isDirty`, so if the user edits the tactic again within the cue window the button immediately reverts to "Update tactic" instead of contradicting the "Unsaved changes" badge.

## Changes
| File | Change |
|------|--------|
| `src/components/tactics/TacticsCommandBar.tsx` | Disable condition, saved-cue state with timeout cleanup, check icon |
| `src/components/tactics/TacticsCommandBar.test.tsx` | New: 5 tests covering disabled/enabled states, preset behavior, cue lifecycle, and the edit-during-cue regression |
| `src/i18n/locales/*.json` (12 locales) | New `tactics.tacticSaved` key, translated per language |

## Test plan
- `npx vitest run src/components/tactics` → 34 passed, 0 failed
- `npm run audit:i18n` → all locales match the English key set
- The edit-during-cue case is pinned by a dedicated regression test (save → cue visible → rerender dirty → cue gone, button re-enabled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a temporary “Saved” confirmation after successfully saving a tactic.
  - Save controls now clearly reflect whether changes are available.
  - Preset tactics can be saved even without detected edits.
  - Added localized saved-confirmation text across supported languages.

- **Tests**
  - Added coverage for save-button states, confirmation timing, and editing during the confirmation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->