### PR TITLE
fix(ui): remove player face portraits and kit graphics from tactics pitch

### DIFF
--- a/src/components/tactics/TacticsPitch.tsx
+++ b/src/components/tactics/TacticsPitch.tsx
@@ -17,7 +17,7 @@ import {
 } from "../squad/SquadTab.helpers";
 import type { TacticsPitchSlot } from "./TacticsTab.helpers";
 import { buildTacticsPlayerContextMenuItems } from "./TacticsContextMenu.helpers";
-import type { KitPattern, PlayerRole, TacticsPhaseSettings } from "../../store/types";
+import type { PlayerRole, TacticsPhaseSettings } from "../../store/types";
 import { getRoleOptions } from "../../lib/playerRoles";
 
 interface TacticsPitchProps {
@@ -28,9 +28,6 @@ interface TacticsPitchProps {
   onRoleChange?: (playerId: string, role: PlayerRole) => void;
   playerRoles?: Record<string, PlayerRole>;
   tacticsPhase?: TacticsPhaseSettings;
-  teamKitPattern?: KitPattern;
-  teamPrimaryColor?: string;
-  teamSecondaryColor?: string;
   comparePlayerId: string | null;
   hoveredSlot: number | null;
   onAssignBestFit?: (playerId: string) => void;
@@ -266,9 +263,6 @@ export default function TacticsPitch({
   onRoleChange,
   playerRoles,
   tacticsPhase,
-  teamKitPattern,
-  teamPrimaryColor,
-  teamSecondaryColor,
   comparePlayerId,
   hoveredSlot,
   onAssignBestFit,
@@ -518,19 +512,8 @@ export default function TacticsPitch({
                               ovr={getPlayerOvr(player)}
                               condition={player.condition}
                               fitTone={fitTone}
-                              avatar={player}
+                              hidePortrait
                               markers={roleMarkers}
-                              jersey={
-                                teamSecondaryColor
-                                  ? {
-                                      primaryColor: teamPrimaryColor ?? "#1a3a6b",
-                                      secondaryColor: teamSecondaryColor,
-                                      pattern: teamKitPattern ?? "Solid",
-                                      number: player.jersey_number,
-                                    }
-                                  : undefined
-                              }
-                              jerseyNumber={player.jersey_number}
                             >
                               {/* Role combobox */}
                               {onRoleChange && (

--- a/src/components/tactics/TacticsTab.tsx
+++ b/src/components/tactics/TacticsTab.tsx
@@ -178,9 +178,6 @@ export default function TacticsTab({
           }}
           playerRoles={team?.player_roles}
           tacticsPhase={team?.tactics_phase}
-          teamKitPattern={team?.kit_pattern}
-          teamPrimaryColor={team?.colors?.primary}
-          teamSecondaryColor={team?.colors?.secondary}
           onAssignBestFit={(playerId) => {
             void handleAssignBestFit(playerId);
           }}

--- a/src/components/ui/PitchToken.tsx
+++ b/src/components/ui/PitchToken.tsx
@@ -37,6 +37,12 @@ export interface PitchTokenProps {
   };
   /** Plain "#N" fallback shown when no kit `jersey` is available. */
   jerseyNumber?: number | null;
+  /**
+   * When true, skips the face avatar and kit jersey graphics, replacing the
+   * avatar with a plain fit-tone ring. Used by the tactics board, where the
+   * portraits and kit colours added clutter without helping tactical setup.
+   */
+  hidePortrait?: boolean;
   /** Role markers stacked at the top-left (max 3 shown). */
   markers?: PitchTokenMarker[];
   /** Optional slot below the name — e.g. a tactical-role combobox. */
@@ -89,6 +95,7 @@ export function PitchToken({
   avatar,
   jersey,
   jerseyNumber,
+  hidePortrait = false,
   markers,
   children,
 }: PitchTokenProps) {
@@ -113,10 +120,14 @@ export function PitchToken({
             {positionAbbr}
           </span>
         </div>
-        <PlayerAvatar
-          player={avatar ?? { full_name: name, match_name: name }}
-          className={`h-11 w-11 overflow-hidden rounded-full ${fitRingClass(fitTone)}`}
-        />
+        {hidePortrait ? (
+          <div className={`h-11 w-11 rounded-full bg-gray-800/60 ${fitRingClass(fitTone)}`} />
+        ) : (
+          <PlayerAvatar
+            player={avatar ?? { full_name: name, match_name: name }}
+            className={`h-11 w-11 overflow-hidden rounded-full ${fitRingClass(fitTone)}`}
+          />
+        )}
         <div className="absolute -bottom-1 -right-1.5 z-10">
           <span className="rounded-full bg-gray-900 px-2 py-0.5 text-xs font-heading font-bold leading-4 text-white ring-1 ring-white/30">
             {ovr}
@@ -124,19 +135,20 @@ export function PitchToken({
         </div>
       </div>
 
-      {jersey ? (
-        <JerseyIcon
-          size="md"
-          primaryColor={jersey.primaryColor}
-          secondaryColor={jersey.secondaryColor}
-          pattern={jersey.pattern}
-          number={jersey.number}
-        />
-      ) : jerseyNumber != null ? (
-        <span className="text-[10px] font-heading font-bold text-white/80">
-          #{jerseyNumber}
-        </span>
-      ) : null}
+      {!hidePortrait &&
+        (jersey ? (
+          <JerseyIcon
+            size="md"
+            primaryColor={jersey.primaryColor}
+            secondaryColor={jersey.secondaryColor}
+            pattern={jersey.pattern}
+            number={jersey.number}
+          />
+        ) : jerseyNumber != null ? (
+          <span className="text-[10px] font-heading font-bold text-white/80">
+            #{jerseyNumber}
+          </span>
+        ) : null)}
 
       <div className="max-w-full truncate text-xs font-heading font-bold uppercase tracking-[0.12em] text-white drop-shadow-sm">
         {name}


### PR DESCRIPTION
## What and why
Closes #429.

The tactics board reused the same PitchToken component as the pre-match squad
screen, which renders a player face avatar and a kit-colored jersey graphic
under each token. Per player feedback (TheFrontzClub, 0.3.0 nightly), these
added visual clutter without helping tactical setup.

Added a `hidePortrait` flag to PitchToken so the tactics board can suppress
the avatar and jersey while leaving the pre-match screen (which shares the
same component) untouched. When hidden, the avatar is replaced by a plain
ring showing the existing fit-tone indicator (green/orange/red), which is
still tactically useful. Position badge, OVR badge, role markers, name, and
condition bar are unchanged.

Also removed the `teamKitPattern`/`teamPrimaryColor`/`teamSecondaryColor`
props that only existed to build the jersey graphic on the tactics pitch.

## How to verify
1. Open a save, go to the Tactics tab.
2. Pitch tokens show position badge, OVR, role markers, name, and condition
   bar — no face portrait or kit jersey graphic.
3. Open Pre-Match Setup for an upcoming fixture — portraits and kit graphics
   still render there, unaffected.
4. `npx vitest run src/components/ui/PitchToken.test.tsx` — new test proves
   `hidePortrait` actually suppresses the graphics (fails on the pre-fix code).

---
## Checklist
- [x] Targets `develop`, branched from an up-to-date `develop`
- [x] Conventional-commit title
- [x] Linked to an issue

**Tests**
- [x] New behaviour has a test that would have failed before this change
- [x] `npm test` passes
- [ ] `cargo test` / `cargo clippy` — not run; no Rust/`src-tauri` files touched

**If this changes the UI**
- [x] Uses design tokens / existing Tailwind classes — no hex literals, no arbitrary values
- [ ] Checked in both light and dark theme — need to verify visually, see below
- [x] Keyboard reachable, visible focus — unaffected; no interactive elements added or changed

## AI assistance
- [x] This change was written or assisted by an AI coding agent
- [x] I have read the diff myself and I stand behind it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated**
  * Tactics views now display player tokens without portraits or jersey graphics for a cleaner pitch layout.
  * Team kit patterns and color customization are no longer shown in tactics displays.
  * Player tokens continue to support their standard avatar and jersey presentation elsewhere in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->